### PR TITLE
Downgrades commons-codec to v1.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,22 @@
+# Package Files
+*.jar
+*.war
+*.ear
+
+# IntelliJ project files
+*.iml
+*.ipr
+*.iws
+.idea
+
+# Eclipse project files
+.project
+.classpath
+.settings
+
+# Build outputs
+*.class
 target
+dependency-reduced-pom.xml
+
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,41 @@
         <junit.version>4.12</junit.version>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <configuration>
+                            <rules>
+                                <dependencyConvergence/>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <!-- This should not exist as it will force SLF4J calls to be delegated to log4j -->
+                                        <exclude>org.slf4j:slf4j-log4j12</exclude>
+                                        <!-- This should not exist as it will force SLF4J calls to be delegated to jul -->
+                                        <exclude>org.slf4j:slf4j-jdk14</exclude>
+                                        <!-- Ensure only the slf4j binding for logback is on the classpath -->
+                                        <exclude>log4j:log4j</exclude>
+                                        <!-- As recommended from the slf4j guide, exclude commons-logging -->
+                                        <exclude>commons-logging:commons-logging</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                            </rules>
+                        </configuration>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -56,7 +91,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.10</version>
+            <version>1.9</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- DropWizard v0.8.4 uses commons codec v1.9 so converge on that

Also:

 - Adds enforcer execution to maven build

   This was already there in the dropwizard-metrics upstream
   [POM](https://github.com/dropwizard/metrics/blob/v3.1.1/pom.xml#L250-L267)

 - Git ignore IDE stuff too