### PR TITLE
Back to Java v1.6 for metrics v3 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,14 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>1.4.1</version>
                 <executions>

--- a/src/main/java/io/dropwizard/metrics/influxdb/InfluxDbReporter.java
+++ b/src/main/java/io/dropwizard/metrics/influxdb/InfluxDbReporter.java
@@ -221,9 +221,9 @@ public final class InfluxDbReporter extends ScheduledReporter {
      */
     private Object sanitizeGauge(Object value) {
         final Object finalValue;
-        if (value instanceof Double && !Double.isFinite((double) value)) {
+        if (value instanceof Double && (Double.isInfinite((Double) value) || Double.isNaN((Double) value))) {
             finalValue = null;
-        } else if (value instanceof Float && !Float.isFinite((float) value)) {
+        } else if (value instanceof Float && (Float.isInfinite((Float) value) || Float.isNaN((Float) value))) {
             finalValue = null;
         } else {
             finalValue = value;

--- a/src/test/java/io/dropwizard/metrics/influxdb/InfluxDbReporterTest.java
+++ b/src/test/java/io/dropwizard/metrics/influxdb/InfluxDbReporterTest.java
@@ -66,7 +66,7 @@ public class InfluxDbReporterTest {
     public void reportsGauges() throws Exception {
         final Gauge gauge = mock(Gauge.class);
         Mockito.when(gauge.getValue()).thenReturn(10L);
-        reporter.report(this.map("gauge", gauge), this.map(), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
+        reporter.report(this.map("gauge", gauge), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
         final ArgumentCaptor<InfluxDbPoint> influxDbPointCaptor = ArgumentCaptor.forClass(InfluxDbPoint.class);
         Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
         InfluxDbPoint point = influxDbPointCaptor.getValue();
@@ -89,7 +89,7 @@ public class InfluxDbReporterTest {
             .groupGauges(true)
             .build(influxDb);
 
-        groupReporter.report(this.map("gauge", gauge), this.map(), this.<Histogram>map(),
+        groupReporter.report(this.map("gauge", gauge), this.<Counter>map(), this.<Histogram>map(),
             this.<Meter>map(), this.<Timer>map());
         final ArgumentCaptor<InfluxDbPoint> influxDbPointCaptor = ArgumentCaptor.forClass(InfluxDbPoint.class);
         Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
@@ -99,7 +99,7 @@ public class InfluxDbReporterTest {
         assertThat(point.getFields()).hasSize(1);
         assertThat(point.getFields()).contains(entry("value", 10L));
 
-        groupReporter.report(this.map("gauge.1", gauge), this.map(), this.<Histogram>map(),
+        groupReporter.report(this.map("gauge.1", gauge), this.<Counter>map(), this.<Histogram>map(),
             this.<Meter>map(), this.<Timer>map());
         Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
         point = influxDbPointCaptor.getValue();
@@ -109,7 +109,7 @@ public class InfluxDbReporterTest {
         assertThat(point.getFields()).contains(entry("1", 10L));
 
         // if metric name terminates in `.' field name should be empty
-        groupReporter.report(this.map("gauge.", gauge), this.map(), this.<Histogram>map(),
+        groupReporter.report(this.map("gauge.", gauge), this.<Counter>map(), this.<Histogram>map(),
             this.<Meter>map(), this.<Timer>map());
         Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
         point = influxDbPointCaptor.getValue();
@@ -122,7 +122,7 @@ public class InfluxDbReporterTest {
         gauges.put("gauge.b", gauge);
         gauges.put("gauge.", gauge);
         gauges.put("gauge", gauge);
-        groupReporter.report(gauges, this.map(), this.<Histogram>map(),
+        groupReporter.report(gauges, this.<Counter>map(), this.<Histogram>map(),
             this.<Meter>map(), this.<Timer>map());
         Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
         point = influxDbPointCaptor.getValue();


### PR DESCRIPTION
metrics v3 only requires java 1.6 so keep this artifact in sync