### PR TITLE
Rounds the reported timestamp down to the unit of time reported

### DIFF
--- a/src/test/java/io/dropwizard/metrics/influxdb/InfluxDbReporterTest.java
+++ b/src/test/java/io/dropwizard/metrics/influxdb/InfluxDbReporterTest.java
@@ -43,6 +43,7 @@ public class InfluxDbReporterTest {
                 .forRegistry(registry)
                 .convertRatesTo(TimeUnit.SECONDS)
                 .convertDurationsTo(TimeUnit.MILLISECONDS)
+                .roundTimestampTo(TimeUnit.MINUTES)
                 .filter(MetricFilter.ALL)
                 .build(influxDb);
 
@@ -57,6 +58,7 @@ public class InfluxDbReporterTest {
         final ArgumentCaptor<InfluxDbPoint> influxDbPointCaptor = ArgumentCaptor.forClass(InfluxDbPoint.class);
         Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
         InfluxDbPoint point = influxDbPointCaptor.getValue();
+        assertThat(point.getTimestamp()).endsWith("000");
         assertThat(point.getMeasurement()).isEqualTo("counter");
         assertThat(point.getFields()).isNotEmpty();
         assertThat(point.getFields()).hasSize(1);


### PR DESCRIPTION
e.g. if we're only publishing every minute the timestamp will round down
to the nearest minute. This reduces InfluxDB storage requirements.

Closes #3