### PR TITLE
Health gauges end in `health` when groupGauges is on

### DIFF
--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
@@ -87,25 +87,25 @@ import org.hibernate.validator.constraints.Range;
  *     <tr>
  *         <td>defaultMeasurementMappings</td>
  *         <td>
- *             health = .*\\.health\\..*<br>
- *             auth = .*\\.auth\\..*<br>
- *             dao = *\\.(jdbi|dao)\\..*<br>
- *             resources = *\\.resources?\\..*<br>
- *             datasources = io\\.dropwizard\\.db\\.ManagedPooledDataSource.*<br>
- *             clients = org\\.apache\\.http\\.client\\.HttpClient.*<br>
- *             client_connections = org\\.apache\\.http\\.conn\\.HttpClientConnectionManager.*<br>
- *             connections = org\\.eclipse\\.jetty\\.server\\.HttpConnectionFactory.*<br>
- *             thread_pools = org\\.eclipse\\.jetty\\.util\\.thread\\.QueuedThreadPool.*<br>
- *             logs = ch\\.qos\\.logback\\.core\\.Appender.*<br>
- *             http_server = io\\.dropwizard\\.jetty\\.MutableServletContextHandler.*<br>
- *             raw_sql = org\\.skife\\.jdbi\\.v2\\.DBI\\.raw-sql<br>
+ *             health = .*\.health(\..*)?<br>
+ *             auth = .*\.auth\..*<br>
+ *             dao = *\.(jdbi|dao)\..*<br>
+ *             resources = *\.resources?\..*<br>
+ *             datasources = io\.dropwizard\.db\.ManagedPooledDataSource.*<br>
+ *             clients = org\.apache\.http\.client\.HttpClient.*<br>
+ *             client_connections = org\.apache\.http\.conn\.HttpClientConnectionManager.*<br>
+ *             connections = org\.eclipse\.jetty\.server\.HttpConnectionFactory.*<br>
+ *             thread_pools = org\.eclipse\.jetty\.util\.thread\.QueuedThreadPool.*<br>
+ *             logs = ch\.qos\.logback\.core\.Appender.*<br>
+ *             http_server = io\.dropwizard\.jetty\.MutableServletContextHandler.*<br>
+ *             raw_sql = org\.skife\.jdbi\.v2\.DBI\.raw-sql<br>
  *             jvm = ^jvm$<br>
- *             jvm_attribute = jvm\\.attribute.*?<br>
- *             jvm_buffers = jvm\\.buffers\\..*<br>
- *             jvm_classloader = jvm\\.classloader.*<br>
- *             jvm_gc = jvm\\.gc\\..*<br>
- *             jvm_memory = jvm\\.memory\\..*<br>
- *             jvm_threads = jvm\\.threads.*<br>
+ *             jvm_attribute = jvm\.attribute.*?<br>
+ *             jvm_buffers = jvm\.buffers\..*<br>
+ *             jvm_classloader = jvm\.classloader.*<br>
+ *             jvm_gc = jvm\.gc\..*<br>
+ *             jvm_memory = jvm\.memory\..*<br>
+ *             jvm_threads = jvm\.threads.*<br>
  *             event_handlers = .*Handler.*
  *          </td>
  *         <td>A map with default measurement mappings.</td>
@@ -156,7 +156,7 @@ public class InfluxDbReporterFactory extends BaseReporterFactory {
     private ImmutableMap<String, String> measurementMappings = ImmutableMap.of();
 
     private ImmutableMap<String, String> defaultMeasurementMappings = ImmutableMap.<String, String>builder()
-        .put("health", ".*\\.health\\..*")
+        .put("health", ".*\\.health(\\..*)?$")
         .put("auth", ".*\\.auth\\..*")
         .put("dao", ".*\\.(jdbi|dao)\\..*")
         .put("resources", ".*\\.resources?\\..*")

--- a/dropwizard-metrics-influxdb/src/test/java/com/izettle/metrics/dw/InfluxDbReporterFactoryTest.java
+++ b/dropwizard-metrics-influxdb/src/test/java/com/izettle/metrics/dw/InfluxDbReporterFactoryTest.java
@@ -86,7 +86,7 @@ public class InfluxDbReporterFactoryTest {
 
     @Test
     public void shouldNotChangeDefaultMappingValueWhenValueIsSame() {
-        ImmutableMap<String,String> mappings = ImmutableMap.of("health", ".*\\.health\\..*");
+        ImmutableMap<String,String> mappings = ImmutableMap.of("health", ".*\\.health(\\..*)?$");
         factory.setMeasurementMappings(mappings);
 
         Map<String, String> defaultMeasurementMappings = factory.getDefaultMeasurementMappings();

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.izettle</groupId>
         <artifactId>izettle-oss</artifactId>
-        <version>1.8</version>
+        <version>1.10</version>
     </parent>
     <artifactId>metrics-parent</artifactId>
     <version>1.0.6-SNAPSHOT</version>


### PR DESCRIPTION
Set regular expression to map health metrics to the measurement `health`
when grouping guages. Since grouping gauges maps all health metrics to a
measurement like for example `com.example.health`.