### PR TITLE
Upgrades DropWizard dependencies to v0.9.1

### DIFF
--- a/dropwizard-metrics-influxdb/pom.xml
+++ b/dropwizard-metrics-influxdb/pom.xml
@@ -4,14 +4,14 @@
     <parent>
         <groupId>com.izettle</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>1.0.8-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>dropwizard-metrics-influxdb</artifactId>
     <name>InfluxDb Integration for DropWizard</name>
 
     <properties>
-        <dropwizard.version>0.8.4</dropwizard.version>
-        <jackson.version>2.5.1</jackson.version>
+        <dropwizard.version>0.9.1</dropwizard.version>
+        <jackson.version>2.6.3</jackson.version>
         <junit.version>4.12</junit.version>
     </properties>
 
@@ -39,6 +39,11 @@
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
+            <version>${dropwizard.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-validation</artifactId>
             <version>${dropwizard.version}</version>
         </dependency>
         <dependency>

--- a/dropwizard-metrics-influxdb/src/test/java/com/izettle/metrics/dw/InfluxDbReporterFactoryTest.java
+++ b/dropwizard-metrics-influxdb/src/test/java/com/izettle/metrics/dw/InfluxDbReporterFactoryTest.java
@@ -10,11 +10,11 @@ import com.google.common.collect.ImmutableMap;
 import com.izettle.metrics.influxdb.InfluxDbHttpSender;
 import com.izettle.metrics.influxdb.InfluxDbReporter;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
+import io.dropwizard.validation.BaseValidator;
 import java.net.URL;
 import java.util.Map;
 import java.util.Set;
 import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
 import javax.validation.Validator;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.reflect.FieldUtils;
@@ -24,7 +24,7 @@ import org.mockito.ArgumentCaptor;
 public class InfluxDbReporterFactoryTest {
 
     private InfluxDbReporterFactory factory = new InfluxDbReporterFactory();
-    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    private final Validator validator = BaseValidator.newValidator();
 
     @Test
     public void isDiscoverable() throws Exception {

--- a/dropwizard-metrics-influxdb/src/test/resources/logback-test.xml
+++ b/dropwizard-metrics-influxdb/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <outputPatternAsHeader>false</outputPatternAsHeader>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="off">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/metrics-influxdb/pom.xml
+++ b/metrics-influxdb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.izettle</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>1.0.8-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>metrics-influxdb</artifactId>
     <name>InfluxDb Integration for Metrics</name>
@@ -13,8 +13,8 @@
     </description>
 
     <properties>
-        <jackson.version>2.5.1</jackson.version>
-        <metrics.version>3.1.1</metrics.version>
+        <jackson.version>2.6.3</jackson.version>
+        <metrics.version>3.1.2</metrics.version>
         <junit.version>4.12</junit.version>
     </properties>
 
@@ -67,5 +67,4 @@
             <version>1.9</version>
         </dependency>
     </dependencies>
-
 </project>

--- a/metrics-influxdb/src/test/resources/logback-test.xml
+++ b/metrics-influxdb/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <outputPatternAsHeader>false</outputPatternAsHeader>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="off">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <relativePath />
     </parent>
     <artifactId>metrics-parent</artifactId>
-    <version>1.0.8-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>InfluxDb Integration</name>
     <url>https://github.com/iZettle/dropwizard-metrics-influxdb</url>
@@ -98,4 +98,16 @@
             </plugin>
         </plugins>
     </build>
+
+    <!-- for convergence -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.12</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
 </project>


### PR DESCRIPTION
- upticks version to v1.1.0 to signify the potential break of
  compatibility

- uses the dropwizard-validation artifacts BaseValidator for testing
  configuration deserialization, since that is what is used for
  dropwizard configuration parsing.