### PR TITLE
Adds configurable connect/read timeouts

### DIFF
--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
@@ -69,6 +69,17 @@ import org.hibernate.validator.constraints.Range;
  *         <td>precision</td>
  *         <td>1m</td>
  *         <td>The precision of timestamps. Does not take into account the quantity, so for example `5m` will be minute precision</td>
+ *     </tr>
+ *     <tr>
+ *         <td>connectTimeout</td>
+ *         <td>1500</td>
+ *         <td>The connect timeout in milliseconds for connecting to InfluxDb.</td>
+ *     </tr>
+ *     <tr>
+ *         <td>readTimeout</td>
+ *         <td>1500</td>
+ *         <td>The read timeout in milliseconds for reading from InfluxDb.</td>
+ *     </tr>
  *     <tr>
  *         <td>auth</td>
  *         <td><i>None</i></td>
@@ -147,6 +158,12 @@ public class InfluxDbReporterFactory extends BaseReporterFactory {
 
     @NotNull
     private String auth = "";
+
+    @Range(min = 500, max = 30000)
+    private int connectTimeout = 1500;
+
+    @Range(min = 500, max = 30000)
+    private int readTimeout = 1500;
 
     @NotNull
     private Duration precision = Duration.minutes(1);
@@ -280,6 +297,26 @@ public class InfluxDbReporterFactory extends BaseReporterFactory {
     }
 
     @JsonProperty
+    public int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    @JsonProperty
+    public void setConnectTimeout(int connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    @JsonProperty
+    public int getReadTimeout() {
+        return readTimeout;
+    }
+
+    @JsonProperty
+    public void setReadTimeout(int readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+
+    @JsonProperty
     public boolean getGroupGauges() {
         return groupGauges;
     }
@@ -334,7 +371,18 @@ public class InfluxDbReporterFactory extends BaseReporterFactory {
     @Override
     public ScheduledReporter build(MetricRegistry registry) {
         try {
-            return builder(registry).build(new InfluxDbHttpSender(protocol, host, port, database, auth, precision.getUnit()));
+            return builder(registry).build(
+                new InfluxDbHttpSender(
+                    protocol,
+                    host,
+                    port,
+                    database,
+                    auth,
+                    precision.getUnit(),
+                    connectTimeout,
+                    readTimeout
+                )
+            );
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
@@ -24,19 +24,24 @@ public class InfluxDbHttpSender implements InfluxDbSender {
     private final String authStringEncoded;
     private final InfluxDbWriteObject influxDbWriteObject;
     private final InfluxDbWriteObjectSerializer influxDbWriteObjectSerializer;
+    private final int connectTimeout;
+    private final int readTimeout;
+
 
     /**
      * Creates a new http sender given connection details.
      *
-     * @param hostname      the influxDb hostname
-     * @param port          the influxDb http port
-     * @param database      the influxDb database to write to
-     * @param authString    the authorization string to be used to connect to InfluxDb, of format username:password
-     * @param timePrecision the time precision of the metrics
+     * @param hostname        the influxDb hostname
+     * @param port            the influxDb http port
+     * @param database        the influxDb database to write to
+     * @param authString      the authorization string to be used to connect to InfluxDb, of format username:password
+     * @param timePrecision   the time precision of the metrics
+     * @param connectTimeout  the connect timeout
+     * @param connectTimeout  the read timeout
      * @throws Exception exception while creating the influxDb sender(MalformedURLException)
      */
     public InfluxDbHttpSender(final String protocol, final String hostname, final int port, final String database, final String authString,
-                              final TimeUnit timePrecision) throws Exception {
+                              final TimeUnit timePrecision, final int connectTimeout, final int readTimeout) throws Exception {
         this.url = new URL(protocol, hostname, port, "/write");
 
         if (authString != null && !authString.isEmpty()) {
@@ -47,6 +52,15 @@ public class InfluxDbHttpSender implements InfluxDbSender {
 
         this.influxDbWriteObject = new InfluxDbWriteObject(database, timePrecision);
         this.influxDbWriteObjectSerializer = new InfluxDbWriteObjectSerializer();
+
+        this.connectTimeout = connectTimeout;
+        this.readTimeout = readTimeout;
+    }
+
+    @Deprecated
+    public InfluxDbHttpSender(final String protocol, final String hostname, final int port, final String database, final String authString,
+                              final TimeUnit timePrecision) throws Exception {
+        this(protocol, hostname, port, database, authString, timePrecision, 1000, 1000);
     }
 
     @Override
@@ -75,8 +89,8 @@ public class InfluxDbHttpSender implements InfluxDbSender {
             con.setRequestProperty("Authorization", "Basic " + authStringEncoded);
         }
         con.setDoOutput(true);
-        con.setConnectTimeout(1000);
-        con.setReadTimeout(1000);
+        con.setConnectTimeout(connectTimeout);
+        con.setReadTimeout(readTimeout);
 
         OutputStream out = con.getOutputStream();
         try {

--- a/metrics-influxdb/src/test/java/sandbox/SendToLocalInfluxDB.java
+++ b/metrics-influxdb/src/test/java/sandbox/SendToLocalInfluxDB.java
@@ -61,7 +61,9 @@ public final class SendToLocalInfluxDB {
             8086,
             "dropwizard",
             "root:root",
-            TimeUnit.MINUTES);
+            TimeUnit.MINUTES,
+            1000,
+            1000);
         final Map<String, String> tags = new HashMap<String, String>();
         tags.put("host", "localhost");
         final InfluxDbReporter reporter = InfluxDbReporter


### PR DESCRIPTION
Sometimes it takes InfluxDb longer to process a request than 1 second. This change increases the default to 1.5 seconds and allows for a configurable connect and read timeout to be set which will hopefully prevent the following type of data discard:

    13:03:04,827 WARN  [com.izettle.metrics.influxdb.InfluxDbReporter] (metrics-influxDb-reporter-1-thread-1) Unable to report to InfluxDB. Discarding data.: java.net.SocketTimeoutException: connect timed out
            at java.net.PlainSocketImpl.socketConnect(Native Method) [rt.jar:1.8.0_72]
            at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350) [rt.jar:1.8.0_72]
            at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206) [rt.jar:1.8.0_72]
            at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188) [rt.jar:1.8.0_72]
            at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392) [rt.jar:1.8.0_72]
            at java.net.Socket.connect(Socket.java:589) [rt.jar:1.8.0_72]
            at sun.security.ssl.SSLSocketImpl.connect(SSLSocketImpl.java:668) [jsse.jar:1.8.0_72]
            at sun.net.NetworkClient.doConnect(NetworkClient.java:175) [rt.jar:1.8.0_72]
            at sun.net.www.http.HttpClient.openServer(HttpClient.java:432) [rt.jar:1.8.0_72]
            at sun.net.www.http.HttpClient.openServer(HttpClient.java:527) [rt.jar:1.8.0_72]
            at sun.net.www.protocol.https.HttpsClient.<init>(HttpsClient.java:264) [rt.jar:1.8.0_72]
            at sun.net.www.protocol.https.HttpsClient.New(HttpsClient.java:367) [rt.jar:1.8.0_72]
            at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.getNewHttpClient(AbstractDelegateHttpsURLConnection.java:191) [rt.jar:1.8.0_72]
            at sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1105) [rt.jar:1.8.0_72]
            at sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:999) [rt.jar:1.8.0_72]
            at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:177) [rt.jar:1.8.0_72]
            at sun.net.www.protocol.http.HttpURLConnection.getOutputStream0(HttpURLConnection.java:1283) [rt.jar:1.8.0_72]
            at sun.net.www.protocol.http.HttpURLConnection.getOutputStream(HttpURLConnection.java:1258) [rt.jar:1.8.0_72]
            at sun.net.www.protocol.https.HttpsURLConnectionImpl.getOutputStream(HttpsURLConnectionImpl.java:250) [rt.jar:1.8.0_72]
            at com.izettle.metrics.influxdb.InfluxDbHttpSender.writeData(InfluxDbHttpSender.java:81) [metrics-influxdb-1.0.2.jar:1.0.2]
            at com.izettle.metrics.influxdb.InfluxDbReporter.report(InfluxDbReporter.java:228) [metrics-influxdb-1.0.2.jar:1.0.2]
            at com.codahale.metrics.ScheduledReporter.report(ScheduledReporter.java:162) [metrics-core-3.1.2.jar:3.1.2]
            at com.codahale.metrics.ScheduledReporter$1.run(ScheduledReporter.java:117) [metrics-core-3.1.2.jar:3.1.2]
            at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [rt.jar:1.8.0_72]
            at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [rt.jar:1.8.0_72]
            at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [rt.jar:1.8.0_72]
            at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [rt.jar:1.8.0_72]
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [rt.jar:1.8.0_72]
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [rt.jar:1.8.0_72]
            at java.lang.Thread.run(Thread.java:745) [rt.jar:1.8.0_72]

Closes #31