### PR TITLE
Adds findbugs and be quieter with exceptions

### DIFF
--- a/findbugs/excludes.xml
+++ b/findbugs/excludes.xml
@@ -1,0 +1,5 @@
+<FindBugsFilter>
+    <Match>
+        <Bug pattern="CRLF_INJECTION_LOGS"/>
+    </Match>
+</FindBugsFilter>

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
@@ -97,7 +97,7 @@ public class InfluxDbHttpSender implements InfluxDbSender {
             out.write(json.getBytes(UTF_8));
             out.flush();
         } finally {
-            if (out != null) out.close();
+            out.close();
         }
 
         int responseCode = con.getResponseCode();

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbReporter.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbReporter.java
@@ -2,6 +2,7 @@ package com.izettle.metrics.influxdb;
 
 import com.codahale.metrics.*;
 import com.izettle.metrics.influxdb.data.InfluxDbPoint;
+import java.net.ConnectException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -227,8 +228,10 @@ public final class InfluxDbReporter extends ScheduledReporter {
             if (influxDb.hasSeriesData()) {
                 influxDb.writeData();
             }
+        } catch (ConnectException e) {
+            LOGGER.warn("Unable to connect to InfluxDB. Discarding data.");
         } catch (Exception e) {
-            LOGGER.warn("Unable to report to InfluxDB. Discarding data.", e);
+            LOGGER.warn("Unable to report to InfluxDB with error '{}'. Discarding data.", e.getMessage());
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,33 @@
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>4.0.0</version>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>3.0.3</version>
+                <configuration>
+                    <effort>Max</effort>
+                    <threshold>Low</threshold>
+                    <xmlOutput>true</xmlOutput>
+                    <failOnError>true</failOnError>
+                    <excludeFilterFile>${session.executionRootDirectory}/findbugs/excludes.xml</excludeFilterFile>
+                    <plugins>
+                        <!-- Add the security plugin from http://find-sec-bugs.github.io/ -->
+                        <plugin>
+                            <groupId>com.h3xstream.findsecbugs</groupId>
+                            <artifactId>findsecbugs-plugin</artifactId>
+                            <version>1.4.5</version>
+                        </plugin>
+                    </plugins>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
- Be quieter with exceptions

  With our current use-case for metrics we don't particularly care too
  much if a metric set has failed to report to influx. This library does
  not retry after some time so it is still useful to have the message
  but not necessarily the stack-trace.

- Adds findbugs analysis to the build