### PR TITLE
WIP: Tag metrics host derived at runtime

### DIFF
--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
@@ -14,6 +14,9 @@ import com.izettle.metrics.influxdb.InfluxDbUdpSender;
 import io.dropwizard.metrics.BaseReporterFactory;
 import io.dropwizard.util.Duration;
 import io.dropwizard.validation.ValidationMethod;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -22,6 +25,8 @@ import javax.activation.UnsupportedDataTypeException;
 import javax.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.hibernate.validator.constraints.Range;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A factory for {@link InfluxDbReporter} instances.
@@ -56,7 +61,7 @@ import org.hibernate.validator.constraints.Range;
  *     <tr>
  *         <td>tags</td>
  *         <td><i>None</i></td>
- *         <td>tags for all metrics reported to InfluxDb.</td>
+ *         <td>tags for all metrics reported to InfluxDb. If host is empty, use getHostName() on startup</td>
  *     </tr>
  *     <tr>
  *         <td>fields</td>
@@ -134,6 +139,9 @@ import org.hibernate.validator.constraints.Range;
  */
 @JsonTypeName("influxdb")
 public class InfluxDbReporterFactory extends BaseReporterFactory {
+
+    public static final Logger LOG = LoggerFactory.getLogger(InfluxDbReporterFactory.class);
+
     @NotEmpty
     private String protocol = "http";
 
@@ -472,7 +480,23 @@ public class InfluxDbReporterFactory extends BaseReporterFactory {
             .includeTimerFields(fields.get("timers"))
             .filter(getFilter())
             .groupGauges(getGroupGauges())
-            .withTags(getTags())
+            .withTags(buildGlobalTags())
             .measurementMappings(buildMeasurementMappings());
+    }
+
+    /**
+     * Build global tags
+     */
+    @VisibleForTesting
+    protected Map<String,String> buildGlobalTags() {
+        Map<String, String> tags = getTags();
+        if (tags.get("host") != null && tags.get("host").isEmpty()) {
+            try {
+                tags.put("host", InetAddress.getLocalHost().getHostName());
+            } catch (UnknownHostException e) {
+                LOG.warn("Could not get hostname for host tag, leaving empty");
+            }
+        }
+        return tags;
     }
 }

--- a/dropwizard-metrics-influxdb/src/test/java/com/izettle/metrics/dw/InfluxDbReporterFactoryTest.java
+++ b/dropwizard-metrics-influxdb/src/test/java/com/izettle/metrics/dw/InfluxDbReporterFactoryTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import com.izettle.metrics.influxdb.InfluxDbHttpSender;
 import com.izettle.metrics.influxdb.InfluxDbReporter;
 import com.izettle.metrics.influxdb.InfluxDbTcpSender;
@@ -14,6 +15,7 @@ import com.izettle.metrics.influxdb.InfluxDbUdpSender;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 import io.dropwizard.validation.BaseValidator;
 import java.net.URL;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import javax.validation.ConstraintViolation;
@@ -78,6 +80,14 @@ public class InfluxDbReporterFactoryTest {
     public void shouldReturnDefaultMeasurementMappings() {
         Map<String, String> measurementMappings = factory.buildMeasurementMappings();
         assertThat(measurementMappings).isEqualTo(factory.getDefaultMeasurementMappings());
+    }
+
+    @Test
+    public void shouldDeriveHostTag() {
+        Map<String, String> tags = new HashMap(ImmutableMap.of("host", ""));
+        factory.setTags(tags);
+        Map<String, String> globalTags = factory.buildGlobalTags();
+        assertThat(globalTags.get("host")).isNotEmpty();
     }
 
     @Test


### PR DESCRIPTION
If the config for "tags" contains an empty host, e.g. host: "", then get
the host at runtime.