### PR TITLE
Tag transformer allows to add tags based on metrics name. Default imp…

### DIFF
--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/tags/NoopTransformer.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/tags/NoopTransformer.java
@@ -1,0 +1,13 @@
+package com.izettle.metrics.influxdb.tags;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class NoopTransformer implements Transformer {
+    @Override
+    public Map<String, String> getTags(String metricName) {
+        Map<String, String> tags = new HashMap<String, String>();
+        tags.put("metricName", metricName);
+        return tags;
+    }
+}

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/tags/PositionBasedTransformer.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/tags/PositionBasedTransformer.java
@@ -1,0 +1,65 @@
+package com.izettle.metrics.influxdb.tags;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Based on tag name and Category mapping this class extracts map of tags from metrics name
+ *
+ * <br>
+ * Example using the category mapping ["className", [5, "com\\.izettle\\.metrics\\.influxdb\\.tags\\.PositionBasedTransformer"]]
+ * a metric called `com.izettle.metrics.influxdb.tags.PositionBasedTransformer.count` will be turned into
+ * a tag:
+ * <pre>
+ *    tags: [[className=PositionBasedTransformer]]
+ * </pre>
+ */
+public class PositionBasedTransformer implements Transformer {
+
+    private static final String SEPARATOR = "\\.";
+
+    private final Map<String, Category> mappings;
+
+    public static class Category {
+        private final int position;
+        private final Pattern mapping;
+
+        public Category(int position, String mapping) {
+            if (position < 0) {
+                throw new IllegalArgumentException("position should be gte 0");
+            }
+            this.position = position;
+            this.mapping = Pattern.compile(mapping);
+        }
+
+        public int getPosition() {
+            return position;
+        }
+
+        Pattern getMapping() {
+            return mapping;
+        }
+    }
+
+    public PositionBasedTransformer(Map<String, Category> mappings) {
+        this.mappings = mappings;
+    }
+
+    @Override
+    public Map<String, String> getTags(String metricsName) {
+        String[] parts = metricsName.split(SEPARATOR);
+        Map<String, String> tags = new HashMap<String, String>();
+
+        for (Map.Entry<String, Category> entry : mappings.entrySet()) {
+            final Pattern pattern = entry.getValue().getMapping();
+            final int position = entry.getValue().position;
+
+            if ((parts.length > position) && pattern.matcher(metricsName).matches()) {
+                tags.put(entry.getKey(), parts[position]);
+            }
+        }
+
+        return tags;
+    }
+}

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/tags/Transformer.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/tags/Transformer.java
@@ -1,0 +1,7 @@
+package com.izettle.metrics.influxdb.tags;
+
+import java.util.Map;
+
+public interface Transformer {
+    Map<String, String> getTags(String metricName);
+}

--- a/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/tags/PositionBasedTransformerTest.java
+++ b/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/tags/PositionBasedTransformerTest.java
@@ -1,0 +1,51 @@
+package com.izettle.metrics.influxdb.tags;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.PatternSyntaxException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class PositionBasedTransformerTest {
+
+    @Test
+    public void shouldExtractMultipleTags() {
+        Map<String, PositionBasedTransformer.Category> mappings = new HashMap<String, PositionBasedTransformer.Category>();
+        mappings.put("className", new PositionBasedTransformer.Category(
+                5, "com\\.izettle\\.metrics\\.influxdb\\.tags\\..*"));
+        mappings.put("function", new PositionBasedTransformer.Category(
+                6, "com\\.izettle\\.metrics\\.influxdb\\.tags\\..*"));
+        PositionBasedTransformer transformer = new PositionBasedTransformer(mappings);
+        assertThat(transformer.getTags("com.izettle.metrics.influxdb.tags.PositionBasedTransformer.count"))
+                .containsEntry("className", "PositionBasedTransformer")
+                .containsEntry("function", "count");
+        assertThat(transformer.getTags("com.izettle.metrics.influxdb.tags.NoopTransformer.count"))
+                .containsEntry("className", "NoopTransformer")
+                .containsEntry("function", "count");
+    }
+
+    @Test
+    public void shouldNotAllowInvalidPosition() {
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+            () -> new PositionBasedTransformer.Category(-1, ".*")
+        );
+    }
+
+    @Test
+    public void shouldIgnoreIncorrectPosition() {
+        Map<String, PositionBasedTransformer.Category> mappings = new HashMap<String, PositionBasedTransformer.Category>();
+        mappings.put("incorrectTag", new PositionBasedTransformer.Category(42, ".*"));
+        PositionBasedTransformer transformer = new PositionBasedTransformer(mappings);
+        assertThat(transformer.getTags("com.izettle.metrics.influxdb.tags.PositionBasedTransformer.count")).isEmpty();
+    }
+
+    @Test
+    public void shouldFailWithIncorrectRegExp() {
+        assertThatExceptionOfType(PatternSyntaxException.class).isThrownBy(
+            () -> new PositionBasedTransformer.Category(1, "[[a-z,\\.\']")
+        );
+    }
+}


### PR DESCRIPTION
…lementation aka NoopTransformer keeps original behaviour - it adds only one tags "metricName"

In my use case there are couple of metrics, which include valuable part of the metrics name. E.g. `com.package.ClassName.method.context` where `context` might depends on external circumstances. 

Proposed approach doesn't change existing behaviour, and adds some flexibility for users - you can implement metrics name to tags mapping based on your use case. Till dropwizard metrics 4.0 is not released yet this might be helpful. 

I hope that will address issue #42 and #63

PR includes implementation `PositionBasedTransformer` which uses regexp based approach to map metric name to tags. Please see `PositionBasedTransformerTest` for more details. 