### PR TITLE
fixed bug with ignoring time precision by InfluxDbUdpSender

### DIFF
--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
@@ -421,7 +421,6 @@ public class InfluxDbReporterFactory extends BaseReporterFactory {
                             port,
                             readTimeout,
                             database,
-                            precision.getUnit(),
                             prefix
                         )
                     );

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbUdpSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbUdpSender.java
@@ -8,10 +8,12 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * An implementation of InfluxDbSender that uses UDP Connection.
- *
+ * <p>
  * Warning: This class uses non encrypted UDP connection to connect to the remote host.
  */
 public class InfluxDbUdpSender extends InfluxDbBaseSender {
+
+    private static final TimeUnit UDP_TIME_PRECISION = TimeUnit.NANOSECONDS;
 
     private final String hostname;
     private final int port;
@@ -23,9 +25,8 @@ public class InfluxDbUdpSender extends InfluxDbBaseSender {
         int port,
         int socketTimeout,
         String database,
-        TimeUnit timePrecision,
         String measurementPrefix) {
-        super(database, timePrecision, measurementPrefix);
+        super(database, UDP_TIME_PRECISION, measurementPrefix);
         this.hostname = hostname;
         this.port = port;
         this.socketTimeout = socketTimeout;

--- a/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/InfluxDbUdpSenderTest.java
+++ b/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/InfluxDbUdpSenderTest.java
@@ -3,7 +3,7 @@ package com.izettle.metrics.influxdb;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.UnknownHostException;
-import java.util.concurrent.TimeUnit;
+
 import org.junit.Test;
 
 public class InfluxDbUdpSenderTest {
@@ -14,7 +14,6 @@ public class InfluxDbUdpSenderTest {
             10080,
             1000,
             "test",
-            TimeUnit.MINUTES,
             ""
         );
         influxDbUdpSender.writeData(new byte[0]);
@@ -27,7 +26,6 @@ public class InfluxDbUdpSenderTest {
             10080,
             1000,
             "test",
-            TimeUnit.MINUTES,
             ""
         );
         assertThat(influxDbUdpSender.writeData(new byte[0]) == 0);

--- a/metrics-influxdb/src/test/java/sandbox/SendToLocalInfluxDB.java
+++ b/metrics-influxdb/src/test/java/sandbox/SendToLocalInfluxDB.java
@@ -55,7 +55,7 @@ public final class SendToLocalInfluxDB {
     }
 
     private static InfluxDbSender GetUdpSender() throws Exception {
-        return new InfluxDbUdpSender("127.0.0.1", 8092, 1000, "dropwizard", TimeUnit.SECONDS, "");
+        return new InfluxDbUdpSender("127.0.0.1", 8092, 1000, "dropwizard", "");
     }
 
     private static InfluxDbSender GetTcpSender() throws Exception {


### PR DESCRIPTION
Hi! There was a bug in InfluxDbUdpSender with time precision, partly described in #65 issue. Without setting time precision in nanoseconds it is unable to use InfluxDB in normal way. I've fixed it. 