### PR TITLE
fixing time-unit issue in TCP Protocol. Line protocol uses nano seconds

### DIFF
--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
@@ -410,7 +410,6 @@ public class InfluxDbReporterFactory extends BaseReporterFactory {
                             port,
                             readTimeout,
                             database,
-                            precision.getUnit(),
                             prefix
                         )
                     );

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbTcpSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbTcpSender.java
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeUnit;
 public class InfluxDbTcpSender extends InfluxDbBaseSender {
 
     private static final int NUM_OF_RETRIES = 2;
-
+    private static final TimeUnit TCP_TIME_PRECISION = TimeUnit.NANOSECONDS;
     private final String hostname;
     private final int port;
     private final int socketTimeout;
@@ -25,16 +25,14 @@ public class InfluxDbTcpSender extends InfluxDbBaseSender {
      * @param port              The port to connect
      * @param socketTimeout     A socket timeout to use
      * @param database          The database to write into
-     * @param timePrecision     The time precision to use
      */
     public InfluxDbTcpSender(
         final String hostname,
         final int port,
         final int socketTimeout,
         final String database,
-        final TimeUnit timePrecision,
         final String measurementPrefix) {
-        super(database, timePrecision, measurementPrefix);
+        super(database, TCP_TIME_PRECISION, measurementPrefix);
         this.hostname = hostname;
         this.port = port;
         this.socketTimeout = socketTimeout;

--- a/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/InfluxDbTcpSenderTest.java
+++ b/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/InfluxDbTcpSenderTest.java
@@ -16,7 +16,6 @@ public class InfluxDbTcpSenderTest {
             10080,
             1000,
             "test",
-            TimeUnit.MINUTES,
             ""
         );
         influxDbTcpSender.writeData(new byte[0]);
@@ -29,7 +28,6 @@ public class InfluxDbTcpSenderTest {
             10080,
             1000,
             "test",
-            TimeUnit.MINUTES,
             ""
         );
         influxDbTcpSender.writeData(new byte[0]);
@@ -43,7 +41,6 @@ public class InfluxDbTcpSenderTest {
             10080,
             1000,
             "test",
-            TimeUnit.MINUTES,
             ""
         );
         assertThat(influxDbTcpSender.writeData(new byte[0]) == 0);

--- a/metrics-influxdb/src/test/java/sandbox/SendToLocalInfluxDB.java
+++ b/metrics-influxdb/src/test/java/sandbox/SendToLocalInfluxDB.java
@@ -59,7 +59,7 @@ public final class SendToLocalInfluxDB {
     }
 
     private static InfluxDbSender GetTcpSender() throws Exception {
-        return new InfluxDbTcpSender("127.0.0.1", 8094, 1000, "dropwzard", TimeUnit.SECONDS, "");
+        return new InfluxDbTcpSender("127.0.0.1", 8094, 1000, "dropwzard",  "");
     }
 
     private static InfluxDbHttpSender GetHttpSender() throws Exception {


### PR DESCRIPTION
We saw a fix for https://github.com/iZettle/dropwizard-metrics-influxdb/issues/65 applied for the UDP protocol.

It was fixed with https://github.com/iZettle/dropwizard-metrics-influxdb/pull/68

TCP has the same issue unfortunately, this pull request will modify the InfluxDB TCP sender to work as expect by the line protocol.