### PR TITLE
Allow grouping all measurements into on with multiple fields

### DIFF
--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSender.java
@@ -1,0 +1,15 @@
+package com.izettle.metrics.influxdb;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ *  Passthrough to ultimately select a different style of serializer: grouped fields on one influxdb protocol line,
+ *  instead of one field per protocol line.
+ */
+public class GroupedInfluxDbHttpSender extends InfluxDbHttpSender {
+    public GroupedInfluxDbHttpSender(String protocol, String hostname, int port, String database, String authString,
+            TimeUnit timePrecision, int connectTimeout, int readTimeout, String measurementPrefix) throws Exception {
+        super(protocol, hostname, port, database, authString, timePrecision, connectTimeout, readTimeout, measurementPrefix,
+              true);
+    }
+}

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSender.java
@@ -2,14 +2,28 @@ package com.izettle.metrics.influxdb;
 
 import java.util.concurrent.TimeUnit;
 
+import com.izettle.metrics.influxdb.data.InfluxDbWriteObject;
+import com.izettle.metrics.influxdb.utils.InfluxDbWriteObjectSerializer;
+
 /**
  *  Passthrough to ultimately select a different style of serializer: grouped fields on one influxdb protocol line,
  *  instead of one field per protocol line.
  */
 public class GroupedInfluxDbHttpSender extends InfluxDbHttpSender {
+    private final String groupMeasurement;
+    
     public GroupedInfluxDbHttpSender(String protocol, String hostname, int port, String database, String authString,
-            TimeUnit timePrecision, int connectTimeout, int readTimeout, String measurementPrefix, String measurement) throws Exception {
-        super(protocol, hostname, port, database, authString, timePrecision, connectTimeout, readTimeout, measurementPrefix, measurement,
-              true);
+            TimeUnit timePrecision, int connectTimeout, int readTimeout, String measurementPrefix, String groupMeasurement) throws Exception {
+        super(protocol, hostname, port, database, authString, timePrecision, connectTimeout, readTimeout, measurementPrefix);
+        this.groupMeasurement = groupMeasurement;
+    }
+
+    @Override
+    public int writeData() throws Exception {
+        InfluxDbWriteObjectSerializer serializer = this.getSerializer();
+        InfluxDbWriteObject writeObject = this.getWriteObject();
+        String linestr = serializer.getGroupedLineProtocolString(writeObject, groupMeasurement);
+        final byte[] line = linestr.getBytes(UTF_8);
+        return super.writeData(line);
     }
 }

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSender.java
@@ -8,8 +8,8 @@ import java.util.concurrent.TimeUnit;
  */
 public class GroupedInfluxDbHttpSender extends InfluxDbHttpSender {
     public GroupedInfluxDbHttpSender(String protocol, String hostname, int port, String database, String authString,
-            TimeUnit timePrecision, int connectTimeout, int readTimeout, String measurementPrefix) throws Exception {
-        super(protocol, hostname, port, database, authString, timePrecision, connectTimeout, readTimeout, measurementPrefix,
+            TimeUnit timePrecision, int connectTimeout, int readTimeout, String measurementPrefix, String measurement) throws Exception {
+        super(protocol, hostname, port, database, authString, timePrecision, connectTimeout, readTimeout, measurementPrefix, measurement,
               true);
     }
 }

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbBaseSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbBaseSender.java
@@ -16,10 +16,18 @@ abstract class InfluxDbBaseSender implements InfluxDbSender {
     static final Charset UTF_8 = StandardCharsets.UTF_8;
     private final InfluxDbWriteObject influxDbWriteObject;
     private final InfluxDbWriteObjectSerializer influxDbWriteObjectSerializer;
+    private final boolean groupedFields;
 
     InfluxDbBaseSender(final String database, final TimeUnit timePrecision, final String measurementPrefix) {
         this.influxDbWriteObject = new InfluxDbWriteObject(database, timePrecision);
         this.influxDbWriteObjectSerializer = new InfluxDbWriteObjectSerializer(measurementPrefix);
+        this.groupedFields = false;
+    }
+
+    InfluxDbBaseSender(final String database, final TimeUnit timePrecision, final String measurementPrefix, final boolean groupedFields) {
+        this.influxDbWriteObject = new InfluxDbWriteObject(database, timePrecision);
+        this.influxDbWriteObjectSerializer = new InfluxDbWriteObjectSerializer(measurementPrefix);
+        this.groupedFields = groupedFields;
     }
 
     @Override
@@ -41,7 +49,10 @@ abstract class InfluxDbBaseSender implements InfluxDbSender {
 
     @Override
     public int writeData() throws Exception {
-        final byte[] line = influxDbWriteObjectSerializer.getLineProtocolString(influxDbWriteObject).getBytes(UTF_8);
+        String linestr = this.groupedFields
+            ? influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject)
+            : influxDbWriteObjectSerializer.getLineProtocolString(influxDbWriteObject);
+        final byte[] line = linestr.getBytes(UTF_8);
 
         return writeData(line);
     }

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbBaseSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbBaseSender.java
@@ -17,17 +17,21 @@ abstract class InfluxDbBaseSender implements InfluxDbSender {
     private final InfluxDbWriteObject influxDbWriteObject;
     private final InfluxDbWriteObjectSerializer influxDbWriteObjectSerializer;
     private final boolean groupedFields;
+    private final String measurement;
 
     InfluxDbBaseSender(final String database, final TimeUnit timePrecision, final String measurementPrefix) {
         this.influxDbWriteObject = new InfluxDbWriteObject(database, timePrecision);
         this.influxDbWriteObjectSerializer = new InfluxDbWriteObjectSerializer(measurementPrefix);
         this.groupedFields = false;
+        this.measurement = null;
     }
 
-    InfluxDbBaseSender(final String database, final TimeUnit timePrecision, final String measurementPrefix, final boolean groupedFields) {
+    InfluxDbBaseSender(final String database, final TimeUnit timePrecision, final String measurementPrefix,
+            final String measurement, final boolean groupedFields) {
         this.influxDbWriteObject = new InfluxDbWriteObject(database, timePrecision);
         this.influxDbWriteObjectSerializer = new InfluxDbWriteObjectSerializer(measurementPrefix);
         this.groupedFields = groupedFields;
+        this.measurement = measurement;
     }
 
     @Override
@@ -50,7 +54,7 @@ abstract class InfluxDbBaseSender implements InfluxDbSender {
     @Override
     public int writeData() throws Exception {
         String linestr = this.groupedFields
-            ? influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject)
+            ? influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject,measurement)
             : influxDbWriteObjectSerializer.getLineProtocolString(influxDbWriteObject);
         final byte[] line = linestr.getBytes(UTF_8);
 

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbBaseSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbBaseSender.java
@@ -16,22 +16,10 @@ abstract class InfluxDbBaseSender implements InfluxDbSender {
     static final Charset UTF_8 = StandardCharsets.UTF_8;
     private final InfluxDbWriteObject influxDbWriteObject;
     private final InfluxDbWriteObjectSerializer influxDbWriteObjectSerializer;
-    private final boolean groupedFields;
-    private final String measurement;
 
     InfluxDbBaseSender(final String database, final TimeUnit timePrecision, final String measurementPrefix) {
         this.influxDbWriteObject = new InfluxDbWriteObject(database, timePrecision);
         this.influxDbWriteObjectSerializer = new InfluxDbWriteObjectSerializer(measurementPrefix);
-        this.groupedFields = false;
-        this.measurement = null;
-    }
-
-    InfluxDbBaseSender(final String database, final TimeUnit timePrecision, final String measurementPrefix,
-            final String measurement, final boolean groupedFields) {
-        this.influxDbWriteObject = new InfluxDbWriteObject(database, timePrecision);
-        this.influxDbWriteObjectSerializer = new InfluxDbWriteObjectSerializer(measurementPrefix);
-        this.groupedFields = groupedFields;
-        this.measurement = measurement;
     }
 
     @Override
@@ -53,9 +41,7 @@ abstract class InfluxDbBaseSender implements InfluxDbSender {
 
     @Override
     public int writeData() throws Exception {
-        String linestr = this.groupedFields
-            ? influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject,measurement)
-            : influxDbWriteObjectSerializer.getLineProtocolString(influxDbWriteObject);
+        String linestr = influxDbWriteObjectSerializer.getLineProtocolString(influxDbWriteObject);
         final byte[] line = linestr.getBytes(UTF_8);
 
         return writeData(line);
@@ -73,5 +59,13 @@ abstract class InfluxDbBaseSender implements InfluxDbSender {
     @Override
     public Map<String, String> getTags() {
         return influxDbWriteObject.getTags();
+    }
+
+    protected InfluxDbWriteObject getWriteObject() {
+        return this.influxDbWriteObject;
+    }
+
+    protected InfluxDbWriteObjectSerializer getSerializer() {
+        return this.influxDbWriteObjectSerializer;
     }
 }

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
@@ -34,9 +34,10 @@ public class InfluxDbHttpSender extends InfluxDbBaseSender {
      */
     public InfluxDbHttpSender(
         final String protocol, final String hostname, final int port, final String database, final String authString,
-        final TimeUnit timePrecision, final int connectTimeout, final int readTimeout, final String measurementPrefix)
+        final TimeUnit timePrecision, final int connectTimeout, final int readTimeout, final String measurementPrefix, 
+        final boolean groupedFields)
         throws Exception {
-        super(database, timePrecision, measurementPrefix);
+        super(database, timePrecision, measurementPrefix, groupedFields);
 
         String endpoint = new URL(protocol, hostname, port, "/write").toString();
         String queryDb = String.format("db=%s", URLEncoder.encode(database, "UTF-8"));
@@ -51,6 +52,14 @@ public class InfluxDbHttpSender extends InfluxDbBaseSender {
 
         this.connectTimeout = connectTimeout;
         this.readTimeout = readTimeout;
+    }
+
+    public InfluxDbHttpSender(
+        final String protocol, final String hostname, final int port, final String database, final String authString,
+        final TimeUnit timePrecision, final int connectTimeout, final int readTimeout, final String measurementPrefix) 
+        throws Exception {
+        this(protocol, hostname, port, database, authString, timePrecision, connectTimeout, readTimeout,
+                           measurementPrefix, false);
     }
 
     @Deprecated

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
@@ -30,15 +30,13 @@ public class InfluxDbHttpSender extends InfluxDbBaseSender {
      * @param timePrecision   the time precision of the metrics
      * @param connectTimeout  the connect timeout
      * @param connectTimeout  the read timeout
-     * @param measurement     common measurement for grouped fields case
      * @throws Exception exception while creating the influxDb sender(MalformedURLException)
      */
     public InfluxDbHttpSender(
         final String protocol, final String hostname, final int port, final String database, final String authString,
-        final TimeUnit timePrecision, final int connectTimeout, final int readTimeout, final String measurementPrefix, 
-        String measurement, final boolean groupedFields)
+        final TimeUnit timePrecision, final int connectTimeout, final int readTimeout, final String measurementPrefix)
         throws Exception {
-        super(database, timePrecision, measurementPrefix, measurement, groupedFields);
+        super(database, timePrecision, measurementPrefix);
 
         String endpoint = new URL(protocol, hostname, port, "/write").toString();
         String queryDb = String.format("db=%s", URLEncoder.encode(database, "UTF-8"));
@@ -53,14 +51,6 @@ public class InfluxDbHttpSender extends InfluxDbBaseSender {
 
         this.connectTimeout = connectTimeout;
         this.readTimeout = readTimeout;
-    }
-
-    public InfluxDbHttpSender(
-        final String protocol, final String hostname, final int port, final String database, final String authString,
-        final TimeUnit timePrecision, final int connectTimeout, final int readTimeout, final String measurementPrefix) 
-        throws Exception {
-        this(protocol, hostname, port, database, authString, timePrecision, connectTimeout, readTimeout,
-                           measurementPrefix, null, false);
     }
 
     @Deprecated

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
@@ -30,14 +30,15 @@ public class InfluxDbHttpSender extends InfluxDbBaseSender {
      * @param timePrecision   the time precision of the metrics
      * @param connectTimeout  the connect timeout
      * @param connectTimeout  the read timeout
+     * @param measurement     common measurement for grouped fields case
      * @throws Exception exception while creating the influxDb sender(MalformedURLException)
      */
     public InfluxDbHttpSender(
         final String protocol, final String hostname, final int port, final String database, final String authString,
         final TimeUnit timePrecision, final int connectTimeout, final int readTimeout, final String measurementPrefix, 
-        final boolean groupedFields)
+        String measurement, final boolean groupedFields)
         throws Exception {
-        super(database, timePrecision, measurementPrefix, groupedFields);
+        super(database, timePrecision, measurementPrefix, measurement, groupedFields);
 
         String endpoint = new URL(protocol, hostname, port, "/write").toString();
         String queryDb = String.format("db=%s", URLEncoder.encode(database, "UTF-8"));
@@ -59,7 +60,7 @@ public class InfluxDbHttpSender extends InfluxDbBaseSender {
         final TimeUnit timePrecision, final int connectTimeout, final int readTimeout, final String measurementPrefix) 
         throws Exception {
         this(protocol, hostname, port, database, authString, timePrecision, connectTimeout, readTimeout,
-                           measurementPrefix, false);
+                           measurementPrefix, null, false);
     }
 
     @Deprecated

--- a/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSenderTest.java
+++ b/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSenderTest.java
@@ -7,9 +7,7 @@ import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.ConnectException;
 import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
@@ -28,7 +26,7 @@ public class GroupedInfluxDbHttpSenderTest {
 
     @Test
     public void shouldNotThrowException() throws Exception {
-        HttpServer server = HttpServer.create(new InetSocketAddress(10081), 0);
+        HttpServer server = HttpServer.create(new InetSocketAddress(10085), 0);
         try {
             server.createContext("/write", new MyHandler());
             server.setExecutor(null); // creates a default executor
@@ -36,7 +34,7 @@ public class GroupedInfluxDbHttpSenderTest {
             InfluxDbHttpSender influxDbHttpSender = new GroupedInfluxDbHttpSender(
                 "http",
                 "localhost",
-                10081,
+                10085,
                 "testdb",
                 "asdf",
                 TimeUnit.MINUTES,

--- a/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSenderTest.java
+++ b/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSenderTest.java
@@ -43,7 +43,14 @@ public class GroupedInfluxDbHttpSenderTest {
                 "",
                 "MyGroup"
             );
+            assertThat(influxDbHttpSender.getSerializer() != null);
+            assertThat(influxDbHttpSender.getWriteObject() != null);
+            assertThat(influxDbHttpSender.getTags().isEmpty());
+            assertThat(influxDbHttpSender.getWriteObject().getDatabase().equals("testdb"));
             assertThat(influxDbHttpSender.writeData(new byte[0]) == 0);
+            
+            influxDbHttpSender.flush();
+            
         } catch (IOException e) {
             throw new IOException(e);
         } finally {

--- a/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSenderTest.java
+++ b/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSenderTest.java
@@ -1,0 +1,55 @@
+package com.izettle.metrics.influxdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.ConnectException;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+
+public class GroupedInfluxDbHttpSenderTest {
+
+    static class MyHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange t) throws IOException {
+            String response = "This is the response";
+            t.sendResponseHeaders(200, response.length());
+            OutputStream os = t.getResponseBody();
+            os.write(response.getBytes());
+            os.close();
+        }
+    }
+
+    @Test
+    public void shouldNotThrowException() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress(10081), 0);
+        try {
+            server.createContext("/write", new MyHandler());
+            server.setExecutor(null); // creates a default executor
+            server.start();
+            InfluxDbHttpSender influxDbHttpSender = new GroupedInfluxDbHttpSender(
+                "http",
+                "localhost",
+                10081,
+                "testdb",
+                "asdf",
+                TimeUnit.MINUTES,
+                1000,
+                1000,
+                "",
+                "MyGroup"
+            );
+            assertThat(influxDbHttpSender.writeData(new byte[0]) == 0);
+        } catch (IOException e) {
+            throw new IOException(e);
+        } finally {
+            server.stop(0);
+        }
+    }
+}

--- a/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/utils/InfluxDbWriteObjectSerializerTest.java
+++ b/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/utils/InfluxDbWriteObjectSerializerTest.java
@@ -55,12 +55,33 @@ public class InfluxDbWriteObjectSerializerTest {
         InfluxDbWriteObjectSerializer influxDbWriteObjectSerializer = new InfluxDbWriteObjectSerializer("");
         String lineString = influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject, "xxx");
         assertThat(lineString).isEqualTo(
-                "xxx bbb.ccc.field1Key=\"field1Value\" 456000\n");
+                "xxx,tag1Key=tag1Value bbb.ccc.field1Key=\"field1Value\" 456000\n");
         InfluxDbPoint point2 = new InfluxDbPoint("www.yyy.zzz", tags, 456l, fields);
         set.add(point2);
         lineString = influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject, "xxx");
         assertThat(lineString).isEqualTo(
-                "xxx bbb.ccc.field1Key=\"field1Value\",yyy.zzz.field1Key=\"field1Value\" 456000\n");
+                "xxx,tag1Key=tag1Value bbb.ccc.field1Key=\"field1Value\",yyy.zzz.field1Key=\"field1Value\" 456000\n");
+    }
+
+    @Test
+    public void groupedLinesShouldFoldValueFields() {
+        Map<String, String> tags = new HashMap<String, String>();
+        tags.put("tag1Key", "tag1Value");
+        Map<String, Object> fields1 = new HashMap<String, Object>();
+        fields1.put("value", "111");
+        Map<String, Object> fields2 = new HashMap<String, Object>();
+        fields2.put("value", "222");
+        InfluxDbPoint point1 = new InfluxDbPoint("aa.bb.cc1", tags, 456l, fields1);
+        InfluxDbPoint point2 = new InfluxDbPoint("aa.bb.cc2", tags, 456l, fields2);
+        Set<InfluxDbPoint> set = new HashSet<InfluxDbPoint>();
+        set.add(point1);
+        set.add(point2);
+        InfluxDbWriteObject influxDbWriteObject = mock(InfluxDbWriteObject.class);
+        when(influxDbWriteObject.getPoints()).thenReturn(set);
+        when(influxDbWriteObject.getPrecision()).thenReturn(TimeUnit.MICROSECONDS);
+        InfluxDbWriteObjectSerializer influxDbWriteObjectSerializer = new InfluxDbWriteObjectSerializer("");
+        String lineString = influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject, "xxx");
+        assertThat(lineString).isEqualTo("xxx,tag1Key=tag1Value bb.cc2=\"222\",bb.cc1=\"111\" 456000\n");
     }
 
     @Test
@@ -78,12 +99,12 @@ public class InfluxDbWriteObjectSerializerTest {
         InfluxDbWriteObjectSerializer influxDbWriteObjectSerializer = new InfluxDbWriteObjectSerializer("");
         String lineString = influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject, "xxx");
         assertThat(lineString).isEqualTo(
-                "xxx aaa.field1Key=\"field1Value\" 456000\n");
+                "xxx,tag1Key=tag1Value aaa.field1Key=\"field1Value\" 456000\n");
         InfluxDbPoint point2 = new InfluxDbPoint("bbb", tags, 456l, fields);
         set.add(point2);
         lineString = influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject, "xxx");
         assertThat(lineString).isEqualTo(
-                "xxx aaa.field1Key=\"field1Value\",bbb.field1Key=\"field1Value\" 456000\n");
+                "xxx,tag1Key=tag1Value aaa.field1Key=\"field1Value\",bbb.field1Key=\"field1Value\" 456000\n");
     }
 
     @Test

--- a/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/utils/InfluxDbWriteObjectSerializerTest.java
+++ b/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/utils/InfluxDbWriteObjectSerializerTest.java
@@ -60,7 +60,30 @@ public class InfluxDbWriteObjectSerializerTest {
         set.add(point2);
         lineString = influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject);
         assertThat(lineString).isEqualTo(
-                "aaa bbb.ccc.field1Key=\"field1Value\",yyy.zzz.field1Key=\"field1Value\" 456000\n");
+                "xxx bbb.ccc.field1Key=\"field1Value\",yyy.zzz.field1Key=\"field1Value\" 456000\n");
+    }
+
+    @Test
+    public void undottedMeasurementShouldFallback() {
+        Map<String, String> tags = new HashMap<String, String>();
+        tags.put("tag1Key", "tag1Value");
+        Map<String, Object> fields = new HashMap<String, Object>();
+        fields.put("field1Key", "field1Value");
+        InfluxDbPoint point1 = new InfluxDbPoint("aaa", tags, 456l, fields);
+        Set<InfluxDbPoint> set = new HashSet<InfluxDbPoint>();
+        set.add(point1);
+        InfluxDbWriteObject influxDbWriteObject = mock(InfluxDbWriteObject.class);
+        when(influxDbWriteObject.getPoints()).thenReturn(set);
+        when(influxDbWriteObject.getPrecision()).thenReturn(TimeUnit.MICROSECONDS);
+        InfluxDbWriteObjectSerializer influxDbWriteObjectSerializer = new InfluxDbWriteObjectSerializer("");
+        String lineString = influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject);
+        assertThat(lineString).isEqualTo(
+                "aaa aaa.field1Key=\"field1Value\" 456000\n");
+        InfluxDbPoint point2 = new InfluxDbPoint("bbb", tags, 456l, fields);
+        set.add(point2);
+        lineString = influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject);
+        assertThat(lineString).isEqualTo(
+                "aaa aaa.field1Key=\"field1Value\",bbb.field1Key=\"field1Value\" 456000\n");
     }
 
     @Test

--- a/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/utils/InfluxDbWriteObjectSerializerTest.java
+++ b/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/utils/InfluxDbWriteObjectSerializerTest.java
@@ -53,12 +53,12 @@ public class InfluxDbWriteObjectSerializerTest {
         when(influxDbWriteObject.getPoints()).thenReturn(set);
         when(influxDbWriteObject.getPrecision()).thenReturn(TimeUnit.MICROSECONDS);
         InfluxDbWriteObjectSerializer influxDbWriteObjectSerializer = new InfluxDbWriteObjectSerializer("");
-        String lineString = influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject);
+        String lineString = influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject, "xxx");
         assertThat(lineString).isEqualTo(
-                "aaa bbb.ccc.field1Key=\"field1Value\" 456000\n");
-        InfluxDbPoint point2 = new InfluxDbPoint("xxx.yyy.zzz", tags, 456l, fields);
+                "xxx bbb.ccc.field1Key=\"field1Value\" 456000\n");
+        InfluxDbPoint point2 = new InfluxDbPoint("www.yyy.zzz", tags, 456l, fields);
         set.add(point2);
-        lineString = influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject);
+        lineString = influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject, "xxx");
         assertThat(lineString).isEqualTo(
                 "xxx bbb.ccc.field1Key=\"field1Value\",yyy.zzz.field1Key=\"field1Value\" 456000\n");
     }
@@ -76,14 +76,14 @@ public class InfluxDbWriteObjectSerializerTest {
         when(influxDbWriteObject.getPoints()).thenReturn(set);
         when(influxDbWriteObject.getPrecision()).thenReturn(TimeUnit.MICROSECONDS);
         InfluxDbWriteObjectSerializer influxDbWriteObjectSerializer = new InfluxDbWriteObjectSerializer("");
-        String lineString = influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject);
+        String lineString = influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject, "xxx");
         assertThat(lineString).isEqualTo(
-                "aaa aaa.field1Key=\"field1Value\" 456000\n");
+                "xxx aaa.field1Key=\"field1Value\" 456000\n");
         InfluxDbPoint point2 = new InfluxDbPoint("bbb", tags, 456l, fields);
         set.add(point2);
-        lineString = influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject);
+        lineString = influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject, "xxx");
         assertThat(lineString).isEqualTo(
-                "aaa aaa.field1Key=\"field1Value\",bbb.field1Key=\"field1Value\" 456000\n");
+                "xxx aaa.field1Key=\"field1Value\",bbb.field1Key=\"field1Value\" 456000\n");
     }
 
     @Test


### PR DESCRIPTION
This an attempt at #71.

Our organization needs to group all the fields under one measurement and transmit them as one measurement.  This alternate serialization can be had by instantiating `GroupedInfluxDbHttpSender` instead of `InfluxDbHttpSender`.

TODO: update unit tests to cover the new code.