### PR TITLE
Add senders

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,25 @@ We default to only report the median (p50), the 99th percentile and the 1m rate
 for timers, and just the 1m rate for meters. Since we report every minute the 5
 and 15 minute rates can be calculated from the 1 minute rate.
 
+## Sender Types
+
+This library can send metrics to InfluxDB directly with `http` (default),
+ `tcp`, or `udp`. In addition to these metrics can also be sent the apps
+logging facility using `logger` or to a Kafka topic, see below.
+
+### Kafka
+
+Metrics can be passed via Kafka by using the `kafka` sender type. Example config:
+
+```
+senderType: kafka
+database: topic@broker1:9092,broker2:9092
+```
+
 ## All Defaults
 
 ```yaml
+senderType: http
 protocol: http
 host: localhost
 port: 8086

--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
@@ -439,7 +439,7 @@ public class InfluxDbReporterFactory extends BaseReporterFactory {
                         )
                     );
                 case KAFKA:
-                	    return builder.build(
+                        return builder.build(
                         new InfluxDBKafkaSender(
                             database,
                             TimeUnit.MILLISECONDS,

--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
@@ -41,6 +41,11 @@ import io.dropwizard.validation.ValidationMethod;
  *         <td>Description</td>
  *     </tr>
  *     <tr>
+ *         <td>senderType</td>
+ *         <td>http</td>
+ *         <td>The sender type (http, tcp, udp, logger, or kafka) used to send metrics to the InfluxDb server.</td>
+ *     </tr>
+ *     <tr>
  *         <td>protocol</td>
  *         <td>http</td>
  *         <td>The protocol (http or https) of the InfluxDb server to report to.</td>

--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
@@ -1,5 +1,17 @@
 package com.izettle.metrics.dw;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import javax.activation.UnsupportedDataTypeException;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.constraints.NotEmpty;
+import org.hibernate.validator.constraints.Range;
+
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -8,20 +20,14 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.izettle.metrics.influxdb.InfluxDbHttpSender;
+import com.izettle.metrics.influxdb.InfluxDbLoggerSender;
 import com.izettle.metrics.influxdb.InfluxDbReporter;
 import com.izettle.metrics.influxdb.InfluxDbTcpSender;
 import com.izettle.metrics.influxdb.InfluxDbUdpSender;
+
 import io.dropwizard.metrics.BaseReporterFactory;
 import io.dropwizard.util.Duration;
 import io.dropwizard.validation.ValidationMethod;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
-import javax.activation.UnsupportedDataTypeException;
-import javax.validation.constraints.NotNull;
-import org.hibernate.validator.constraints.NotEmpty;
-import org.hibernate.validator.constraints.Range;
 
 /**
  * A factory for {@link InfluxDbReporter} instances.
@@ -420,6 +426,14 @@ public class InfluxDbReporterFactory extends BaseReporterFactory {
                             port,
                             readTimeout,
                             database,
+                            prefix
+                        )
+                    );
+                case LOGGER:
+                    return builder.build(
+                        new InfluxDbLoggerSender(
+                            database,
+                            TimeUnit.MILLISECONDS,
                             prefix
                         )
                     );

--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.izettle.metrics.influxdb.InfluxDBKafkaSender;
 import com.izettle.metrics.influxdb.InfluxDbHttpSender;
 import com.izettle.metrics.influxdb.InfluxDbLoggerSender;
 import com.izettle.metrics.influxdb.InfluxDbReporter;
@@ -437,6 +438,14 @@ public class InfluxDbReporterFactory extends BaseReporterFactory {
                             prefix
                         )
                     );
+                case KAFKA:
+                	    return builder.build(
+                        new InfluxDBKafkaSender(
+                            database,
+                            TimeUnit.MILLISECONDS,
+                            prefix
+                        )
+                     );
                 default:
                     throw new UnsupportedDataTypeException("The Sender Type is not supported. ");
             }

--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/SenderType.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/SenderType.java
@@ -6,5 +6,7 @@ package com.izettle.metrics.dw;
 public enum SenderType {
     HTTP,
     TCP,
-    UDP;
+    UDP,
+    LOGGER,
+    KAFKA;
 }

--- a/metrics-influxdb/pom.xml
+++ b/metrics-influxdb/pom.xml
@@ -18,6 +18,11 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>0.11.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
         </dependency>

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDBKafkaSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDBKafkaSender.java
@@ -9,7 +9,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 
 public class InfluxDBKafkaSender extends InfluxDbBaseSender {
-    private final String KAFKA_CLIENT_ID = "metrics_influxdb_reporter";
+    private static final String KAFKA_CLIENT_ID = "metrics_influxdb_reporter";
     private final KafkaProducer<byte[], byte[]> kafkaProducer;
     private final String topic;
 

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDBKafkaSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDBKafkaSender.java
@@ -1,0 +1,40 @@
+package com.izettle.metrics.influxdb;
+
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+
+public class InfluxDBKafkaSender extends InfluxDbBaseSender {
+    private final String KAFKA_CLIENT_ID = "metrics_influxdb_reporter";
+    private final KafkaProducer<byte[], byte[]> kafkaProducer;
+    private final String topic;
+
+    public InfluxDBKafkaSender(String database, TimeUnit timePrecision, String measurementPrefix) {
+        super(database, timePrecision, measurementPrefix);
+        int idx = database.indexOf("@");
+        String hosts;
+        if (idx != -1) {
+            topic = database.substring(0, idx);
+            hosts = database.substring(idx + 1);
+        } else {
+            throw new IllegalArgumentException("invalid database format: " + database +", expected: topic@host1,host2...");
+        }
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, hosts);
+        props.put(ProducerConfig.CLIENT_ID_CONFIG, KAFKA_CLIENT_ID);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        kafkaProducer = new KafkaProducer<>(props);
+    }
+
+    @Override
+    protected int writeData(byte[] line) throws Exception {
+        ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(topic, null, line);
+        kafkaProducer.send(record);
+        return 0;
+    }
+}

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbLoggerSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbLoggerSender.java
@@ -1,0 +1,21 @@
+package com.izettle.metrics.influxdb;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.codec.Charsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InfluxDbLoggerSender extends InfluxDbBaseSender {
+
+	private static final Logger logger = LoggerFactory.getLogger(InfluxDbLoggerSender.class);
+	public InfluxDbLoggerSender(String database, TimeUnit timePrecision, String measurementPrefix) {
+		super(database, timePrecision, measurementPrefix);
+	}
+
+	@Override
+	protected int writeData(byte[] line) throws Exception {
+		logger.info(new String(line, Charsets.UTF_8));
+		return 0;
+	}
+}

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbLoggerSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbLoggerSender.java
@@ -8,14 +8,15 @@ import org.slf4j.LoggerFactory;
 
 public class InfluxDbLoggerSender extends InfluxDbBaseSender {
 
-	private static final Logger logger = LoggerFactory.getLogger(InfluxDbLoggerSender.class);
-	public InfluxDbLoggerSender(String database, TimeUnit timePrecision, String measurementPrefix) {
-		super(database, timePrecision, measurementPrefix);
-	}
+    private static final Logger logger = LoggerFactory.getLogger(InfluxDbLoggerSender.class);
 
-	@Override
-	protected int writeData(byte[] line) throws Exception {
-		logger.info(new String(line, Charsets.UTF_8));
-		return 0;
-	}
+    public InfluxDbLoggerSender(String database, TimeUnit timePrecision, String measurementPrefix) {
+        super(database, timePrecision, measurementPrefix);
+    }
+
+    @Override
+    protected int writeData(byte[] line) throws Exception {
+        logger.info(new String(line, Charsets.UTF_8));
+        return 0;
+    }
 }


### PR DESCRIPTION
Added 2 implementations of InfluxDbBaseSender:

* InfluxDbLoggerSender - writes out influx db records to slf4j
* InfluxDBKafkaSender - writes out influx db records to kafka