### PR TITLE
Introduce new default percentile fields to push

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ protocol: http
 host: localhost
 port: 8086
 tags: {} # global tags, e.g. environment or host
-# only push the median (p50), the 99th percentile and the 1m rate
+# push median (p50), some percentiles and the 1m rate
 fields:
-  timers: [p50, p99, m1_rate]
+  timers: [p50, p75, p95, p99, p999, m1_rate]
   meters: [m1_rate]
 groupGauges: yes
 # exclude some pre-calculated metrics

--- a/dropwizard-metrics-influxdb/pom.xml
+++ b/dropwizard-metrics-influxdb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.izettle</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>1.1.10-SNAPSHOT</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
     <artifactId>dropwizard-metrics-influxdb</artifactId>
     <name>InfluxDb Integration for DropWizard</name>

--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
@@ -60,7 +60,7 @@ import org.hibernate.validator.constraints.Range;
  *     </tr>
  *     <tr>
  *         <td>fields</td>
- *         <td>timers = p50, p99, m1_rate<br>meters = m1_rate</td>
+ *         <td>timers = p50, p75, p95, p99, p999, m1_rate<br>meters = m1_rate</td>
  *         <td>fields by metric type to reported to InfluxDb.</td>
  *     </tr>
  *     <tr>
@@ -152,7 +152,7 @@ public class InfluxDbReporterFactory extends BaseReporterFactory {
     @NotEmpty
     private ImmutableMap<String, ImmutableSet<String>> fields = ImmutableMap.of(
         "timers",
-        ImmutableSet.of("p50", "p99", "m1_rate"),
+        ImmutableSet.of("p50", "p75", "p95", "p99", "p999", "m1_rate"),
         "meters",
         ImmutableSet.of("m1_rate"));
 

--- a/metrics-influxdb/pom.xml
+++ b/metrics-influxdb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.izettle</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>1.1.10-SNAPSHOT</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
     <artifactId>metrics-influxdb</artifactId>
     <name>InfluxDb Integration for Metrics</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>com.izettle</groupId>
         <artifactId>izettle-oss</artifactId>
-        <version>1.11</version>
+        <version>1.14</version>
         <relativePath />
     </parent>
     <artifactId>metrics-parent</artifactId>
-    <version>1.1.10-SNAPSHOT</version>
+    <version>1.2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>InfluxDb Integration</name>
     <url>https://github.com/iZettle/dropwizard-metrics-influxdb</url>


### PR DESCRIPTION
By pushing new fields by default this change may have unintended
consequences which is why the minor version is ticked up.