### PR TITLE
Add option to abbreviate package names

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add the dependency to your project:
 ```
 
 If you have a local influxdb running the bare minimum configuration to put in
-your dropwizard apps yaml is:
+your Dropwizard app's yaml is:
 
 ```yaml
 # Metrics reporting
@@ -70,7 +70,7 @@ measurements in influxdb:
     resources
     thread_pools
 
-You'll likely want to report to a remote influxdb server though so a typical
+You'll likely want to report to a remote InfluxDB server though so a typical
 configuration looks more like this:
 
 ```yaml
@@ -90,7 +90,7 @@ metrics:
 
 ## Default configuration
 
-The Dropwizard InfluxDb reporter factory comes with some sensible defaults. Some
+The Dropwizard InfluxDB reporter factory comes with some sensible defaults. Some
 of the defaults are for reducing storage requirements in the database (1m
 precision reporting every minute and some default exclusions for
 example). Others are to get a better fit for the influx model (gauge grouping
@@ -153,6 +153,17 @@ We default to only report the median (p50), the 99th percentile and the 1m rate
 for timers, and just the 1m rate for meters. Since we report every minute the 5
 and 15 minute rates can be calculated from the 1 minute rate.
 
+### Package name abbreviation
+
+Package name abbreviation is disabled by default. When enabled it will
+abbreviate `metricName` tags so that
+`org.eclipse.jetty.util.thread.QueuedThreadPool.dw` becomes
+`o.e.j.u.t.QueuedThreadPool.dw`.
+
+Metric names that does not look like a conventional fully qualified class
+or method name will not be abbreviated, which means that for example
+`jvm.threads.used` will remain unchanged.
+
 ## All Defaults
 
 ```yaml
@@ -165,6 +176,7 @@ fields:
   timers: [p50, p75, p95, p99, p999, m1_rate]
   meters: [m1_rate]
 groupGauges: yes
+abbreviatePackageNames: no
 # exclude some pre-calculated metrics
 excludes:
   - ch.qos.logback.core.Appender.debug

--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/PackageNameAbbreviator.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/PackageNameAbbreviator.java
@@ -1,0 +1,17 @@
+package com.izettle.metrics.dw;
+
+import java.util.regex.Pattern;
+
+public class PackageNameAbbreviator {
+
+    // Capture the first letter of all dot-separated words that comes before the first capitalized word. E.g:
+    // Input:      org.example.MyClass.myMethod
+    // Captures:   ^   ^
+    private Pattern pattern = Pattern.compile("([a-z])\\w+(?=.*\\.[A-Z])");
+
+    public String abbreviate(String fullyQualifiedName) {
+        return pattern
+            .matcher(fullyQualifiedName)
+            .replaceAll("$1");
+    }
+}

--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/PackageNameAbbreviator.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/PackageNameAbbreviator.java
@@ -7,7 +7,7 @@ public class PackageNameAbbreviator {
     // Capture the first letter of all dot-separated words that comes before the first capitalized word. E.g:
     // Input:      org.example.MyClass.myMethod
     // Captures:   ^   ^
-    private Pattern pattern = Pattern.compile("([a-z])\\w+(?=.*\\.[A-Z])");
+    private static Pattern pattern = Pattern.compile("([a-z])\\w+(?=.*\\.[A-Z])");
 
     public String abbreviate(String fullyQualifiedName) {
         return pattern

--- a/dropwizard-metrics-influxdb/src/test/java/com/izettle/metrics/dw/InfluxDbReporterFactoryTest.java
+++ b/dropwizard-metrics-influxdb/src/test/java/com/izettle/metrics/dw/InfluxDbReporterFactoryTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.ScheduledReporter;
 import com.google.common.collect.ImmutableMap;
 import com.izettle.metrics.influxdb.InfluxDbHttpSender;
 import com.izettle.metrics.influxdb.InfluxDbReporter;
@@ -39,6 +40,15 @@ public class InfluxDbReporterFactoryTest {
         Set<ConstraintViolation<InfluxDbReporterFactory>> violations = validator.validate(factory);
         assertThat(violations).hasSize(0);
     }
+
+    @Test
+    public void shouldNotAcceptInvalidMeasurementMappings() throws Exception {
+        ImmutableMap<String, String> mappings = ImmutableMap.of("health", "*.][healthchecks.**");
+        factory.setMeasurementMappings(mappings);
+        Set<ConstraintViolation<InfluxDbReporterFactory>> violations = validator.validate(factory);
+        assertThat(violations).hasSize(1);
+    }
+
 
     @Test
     public void testNoAddressResolutionForInfluxDb() throws Exception {
@@ -197,5 +207,12 @@ public class InfluxDbReporterFactoryTest {
         final InfluxDbUdpSender influxDb = argument.getValue();
 
         assertThat(getField(influxDb, InfluxDbUdpSender.class, "socketTimeout")).isEqualTo(3000);
+    }
+
+    @Test
+    public void shouldBuildDefaultConfig() {
+        assertThat(
+            factory.build(mock(MetricRegistry.class))
+        ).isNotNull();
     }
 }

--- a/dropwizard-metrics-influxdb/src/test/java/com/izettle/metrics/dw/PackageNameAbbreviatorTest.java
+++ b/dropwizard-metrics-influxdb/src/test/java/com/izettle/metrics/dw/PackageNameAbbreviatorTest.java
@@ -1,0 +1,28 @@
+package com.izettle.metrics.dw;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.izettle.metrics.dw.PackageNameAbbreviator;
+import org.junit.Test;
+
+public class PackageNameAbbreviatorTest {
+
+    PackageNameAbbreviator abbreviator = new PackageNameAbbreviator();
+
+    @Test
+    public void shouldAbbreviateCorrectly() {
+        assertAbbreviatesTo("com.izettle.project.server.resources.TestResource.fooBar", "c.i.p.s.r.TestResource.fooBar");
+        assertAbbreviatesTo("com.izettle.TestClass.one_time.foo", "c.i.TestClass.one_time.foo");
+        assertAbbreviatesTo("TestClass.foo", "TestClass.foo");
+        assertAbbreviatesTo("CustomName", "CustomName");
+        assertAbbreviatesTo("jvm.threads.used", "jvm.threads.used");
+        assertAbbreviatesTo("org.eclipse.jetty.server.HttpConnectionFactory.8081.connections", "o.e.j.s.HttpConnectionFactory.8081.connections");
+        assertAbbreviatesTo("jvm.memory.pools.Compressed-Class-Space.committed", "j.m.p.Compressed-Class-Space.committed");
+    }
+
+    private void assertAbbreviatesTo(String fullyQualifiedName, String expected) {
+        assertThat(abbreviator.abbreviate(fullyQualifiedName))
+            .isEqualTo(expected);
+    }
+
+}


### PR DESCRIPTION
For example:
    `com.izettle.api.purchase.report.PurchaseReportResource.getPurchases`

...becomes:
    `c.i.a.p.r.PurchaseReportResource.getPurchases`

See `PackageNameAbbreviatorTest` for more examples.

Purpose is to make charts like this more readable:
![image](https://user-images.githubusercontent.com/1684261/31543107-fb2aaca2-b014-11e7-9863-b2fb49137a80.png)

---

An alternative solution is to implement this in Metrics, but that's a much longer term solution (if the maintainers even think that it belongs there).

Closes #63