### PR TITLE
Fix reserved influxdb field name when grouping gauges

### DIFF
--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbReporter.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbReporter.java
@@ -271,8 +271,6 @@ public final class InfluxDbReporter extends ScheduledReporter {
                 // avoid influxdb-keyword field like time or tag, see https://github.com/influxdata/influxdb/issues/1834
                 if (fieldName.equalsIgnoreCase("time"))
                     fieldName="time_";
-                else if (fieldName.equals("tag"))
-                    fieldName="tag_";
             } else {
                 // no `.` to group by in the metric name, just report the metric as is
                 metricName = entry.getKey();

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbReporter.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbReporter.java
@@ -263,11 +263,16 @@ public final class InfluxDbReporter extends ScheduledReporter {
         Map<String, Map<String, Gauge>> groupedGauges = new HashMap<String, Map<String, Gauge>>();
         for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
             final String metricName;
-            final String fieldName;
+            String fieldName;
             int lastDotIndex = entry.getKey().lastIndexOf(".");
             if (lastDotIndex != -1) {
                 metricName = entry.getKey().substring(0, lastDotIndex);
                 fieldName = entry.getKey().substring(lastDotIndex + 1);
+                // avoid influxdb-keyword field like time or tag, see https://github.com/influxdata/influxdb/issues/1834
+                if (fieldName.equalsIgnoreCase("time"))
+                    fieldName="time_";
+                else if (fieldName.equals("tag"))
+                    fieldName="tag_";
             } else {
                 // no `.` to group by in the metric name, just report the metric as is
                 metricName = entry.getKey();


### PR DESCRIPTION
When collecting metrics having the same name as reserved influxdb keyword (time or tag), append an underscore to the field name to avoid the naming conflict.