### PR TITLE
Add tag transformer to dropwizard-metrics-influxdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ are for out-of-the-box Dropwizard metrics as well as the
 [recommended](http://www.dropwizard.io/manual/core.html#organizing-your-project)
 Dropwizard project layout.
 
+### Tags
+
+Tags for a metric is created by a class implementing the `Transform` interface
+configured by `tagsTransformer`. By default the `ClassBasedTransformer` is used
+and it creates tha following tags `metricName`, `package`, `className`, and
+`method`. 
+
 ### Gauge Grouping
 
 Gauge grouping is enabled by default. This will turn a set of metrics into a
@@ -232,4 +239,5 @@ durationUnit: MILLISECONDS
 rateUnit: SECONDS
 # default inherited from MetricsFactory
 frequency: 1m
+tagsTransformer: com.izettle.metrics.influxdb.tags.ClassBasedTransformer # default
 ```

--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ Dropwizard project layout.
 
 ### Tags
 
-Tags for a metric is created by a class implementing the `Transform` interface
+Tags for a metric are created by a class implementing the `Transform` interface
 configured by `tagsTransformer`. By default the `ClassBasedTransformer` is used
-and it creates tha following tags `metricName`, `package`, `className`, and
+and it creates tha following tags: `metricName`, `package`, `className`, and
 `method`. 
 
 ### Gauge Grouping

--- a/dropwizard-metrics-influxdb/pom.xml
+++ b/dropwizard-metrics-influxdb/pom.xml
@@ -41,8 +41,10 @@
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
-            <artifactId>findbugs</artifactId>
+            <artifactId>annotations</artifactId>
             <version>3.0.1</version>
+            <optional>true</optional>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/dropwizard-metrics-influxdb/pom.xml
+++ b/dropwizard-metrics-influxdb/pom.xml
@@ -39,5 +39,10 @@
             <artifactId>commons-lang3</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>findbugs</artifactId>
+            <version>3.0.1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/TagTransformerType.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/TagTransformerType.java
@@ -1,0 +1,7 @@
+package com.izettle.metrics.dw;
+
+public enum TagTransformerType {
+    NOOP,
+    POSITION_BASED,
+    CLASS_BASED
+}

--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/TagTransformerType.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/TagTransformerType.java
@@ -1,7 +1,0 @@
-package com.izettle.metrics.dw;
-
-public enum TagTransformerType {
-    NOOP,
-    POSITION_BASED,
-    CLASS_BASED
-}

--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/tags/ClassBasedTransformer.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/tags/ClassBasedTransformer.java
@@ -1,0 +1,9 @@
+package com.izettle.metrics.dw.tags;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@JsonTypeName("ClassBased")
+@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS")
+public class ClassBasedTransformer extends com.izettle.metrics.influxdb.tags.ClassBasedTransformer implements Transformer {
+}

--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/tags/NoopTransformer.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/tags/NoopTransformer.java
@@ -1,0 +1,9 @@
+package com.izettle.metrics.dw.tags;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@JsonTypeName("Noop")
+@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS")
+public class NoopTransformer extends com.izettle.metrics.influxdb.tags.NoopTransformer implements Transformer {
+}

--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/tags/PositionBasedTransformer.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/tags/PositionBasedTransformer.java
@@ -1,0 +1,14 @@
+package com.izettle.metrics.dw.tags;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Map;
+
+@JsonTypeName("PositionBased")
+@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS")
+public class PositionBasedTransformer extends com.izettle.metrics.influxdb.tags.PositionBasedTransformer implements Transformer {
+
+    public PositionBasedTransformer(Map<String, Category> mappings) {
+        super(mappings);
+    }
+}

--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/tags/Transformer.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/tags/Transformer.java
@@ -1,0 +1,10 @@
+package com.izettle.metrics.dw.tags;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.dropwizard.jackson.Discoverable;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_INTERFACE")
+public interface Transformer extends Discoverable, com.izettle.metrics.influxdb.tags.Transformer {
+}

--- a/dropwizard-metrics-influxdb/src/main/resources/META-INF/services/com.izettle.metrics.dw.tags.Transformer
+++ b/dropwizard-metrics-influxdb/src/main/resources/META-INF/services/com.izettle.metrics.dw.tags.Transformer
@@ -1,0 +1,3 @@
+com.izettle.metrics.dw.tags.ClassBasedTransformer
+com.izettle.metrics.dw.tags.NoopTransformer
+com.izettle.metrics.dw.tags.PathBasedTransformer

--- a/dropwizard-metrics-influxdb/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
+++ b/dropwizard-metrics-influxdb/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
@@ -1,0 +1,1 @@
+com.izettle.metrics.dw.tags.Transformer

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/tags/ClassBasedTransformer.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/tags/ClassBasedTransformer.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 /**
  * Extract the class name and function from the metricName.
  */
-public class ClassBasedTransformer implements Transformer{
+public class ClassBasedTransformer implements Transformer {
 
     private static final Pattern PACKAGE = Pattern.compile("(.*)\\.[A-Z].*");
     private static final Pattern CLASS_NAME = Pattern.compile(".*\\.([A-Z][^\\.]*).*");

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/tags/ClassBasedTransformer.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/tags/ClassBasedTransformer.java
@@ -5,21 +5,31 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Extract the class name and function from the metricName.
+ */
 public class ClassBasedTransformer implements Transformer{
 
-    private final Pattern className;
-
-    public ClassBasedTransformer() {
-        this.className = Pattern.compile("\\w+(?= )");
-    }
+    private static final Pattern PACKAGE = Pattern.compile("(.*)\\.[A-Z].*");
+    private static final Pattern CLASS_NAME = Pattern.compile(".*\\.([A-Z][^\\.]*).*");
+    private static final Pattern METHOD = Pattern.compile(".*\\.[A-Z][^\\.]*\\.(.*)");
 
     @Override
     public Map<String, String> getTags(String metricsName) {
         Map<String, String> tags = new HashMap<String, String>();
+        tags.put("metricName", metricsName);
 
-        Matcher classMatcher = className.matcher(metricsName);
+        Matcher packageMatcher = PACKAGE.matcher(metricsName);
+        if(packageMatcher.find()) {
+            tags.put("package", packageMatcher.group(1));
+        }
+        Matcher classMatcher = CLASS_NAME.matcher(metricsName);
         if(classMatcher.find()) {
-            tags.put("class", classMatcher.group(0));
+            tags.put("className", classMatcher.group(1));
+        }
+        Matcher methodMatcher = METHOD.matcher(metricsName);
+        if(methodMatcher.find()) {
+            tags.put("method", methodMatcher.group(1));
         }
         return tags;
     }

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/tags/ClassBasedTransformer.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/tags/ClassBasedTransformer.java
@@ -1,0 +1,26 @@
+package com.izettle.metrics.influxdb.tags;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ClassBasedTransformer implements Transformer{
+
+    private final Pattern className;
+
+    public ClassBasedTransformer() {
+        this.className = Pattern.compile("\\w+(?= )");
+    }
+
+    @Override
+    public Map<String, String> getTags(String metricsName) {
+        Map<String, String> tags = new HashMap<String, String>();
+
+        Matcher classMatcher = className.matcher(metricsName);
+        if(classMatcher.find()) {
+            tags.put("class", classMatcher.group(0));
+        }
+        return tags;
+    }
+}

--- a/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/tags/ClassBasedTransformerTest.java
+++ b/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/tags/ClassBasedTransformerTest.java
@@ -1,0 +1,28 @@
+package com.izettle.metrics.influxdb.tags;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class ClassBasedTransformerTest {
+
+    @Test
+    public void shouldFindClassNames() {
+
+        assertThat(new ClassBasedTransformer().getTags("com.izettle.metrics.influxdb.tags.ClassBasedTransformer.count"))
+            .containsEntry("package", "com.izettle.metrics.influxdb.tags")
+            .containsEntry("className", "ClassBasedTransformer")
+            .containsEntry("method", "count");
+
+        assertThat(new ClassBasedTransformer().getTags("com.izettle.metrics.influxdb.tags.ClassBasedTransformer"))
+            .containsEntry("package", "com.izettle.metrics.influxdb.tags")
+            .containsEntry("className", "ClassBasedTransformer")
+            .doesNotContainKeys("method");
+
+        assertThat(new ClassBasedTransformer().getTags("metric.without.class"))
+            .containsEntry("metricName", "metric.without.class")
+            .doesNotContainKeys("package")
+            .doesNotContainKeys("className")
+            .doesNotContainKeys("method");
+    }
+}


### PR DESCRIPTION
This adds support in `dropwizard-metrics-influxdb` to configure a (tag) `Transformer`. And by default this is set to `ClassBasedTransformer`.

Closes #63
Conflicts with #75