### PR TITLE
added optional measurement name transformer

### DIFF
--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/data/MeasurementNameTransformer.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/data/MeasurementNameTransformer.java
@@ -1,0 +1,5 @@
+package com.izettle.metrics.influxdb.data;
+
+public interface MeasurementNameTransformer {
+    String transform(String name);
+}


### PR DESCRIPTION
Option to implement your own measurement name transformer allows, for example:
 * clean up your measurement names with regexp or even something more complicated
 * add custom prefixes/suffixes based on some rules
 * use cases where your tags are part of the measurement name

Since there is already an option to provide a custom tag extractor, the same flexibility for measurement names would be nice to have.