### PR TITLE
Unsecure ssl support

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ excludes:
   - jvm.memory.pools.PS-Survivor-Space.usage
 precision: 1m # only store time precision to the minute
 prefix: ""
+trustAllCerts: false
+trustAllHostnames: false
 database: ""
 auth: ""
 measurementMappings: {}

--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
@@ -301,7 +301,7 @@ public class InfluxDbReporterFactory extends BaseReporterFactory {
     }
     
     @JsonProperty
-    public Boolean isTrustAllCerts(Boolean trustAllCerts) {
+    public Boolean isTrustAllCerts() {
     	return this.trustAllCerts;
     }
     
@@ -311,7 +311,7 @@ public class InfluxDbReporterFactory extends BaseReporterFactory {
     }
     
     @JsonProperty
-    public Boolean isTrustAllHostnames(Boolean trustAllHostnames) {
+    public Boolean isTrustAllHostnames() {
     	return this.trustAllHostnames;
     }
     

--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
@@ -67,6 +67,16 @@ import io.dropwizard.validation.ValidationMethod;
  *         <td>The prefix for Metric key names (measurement) to report to InfluxDb.</td>
  *     </tr>
  *     <tr>
+ *         <td>trustAllCerts</td>
+ *         <td>false</td>
+ *         <td>Whether we should trust all certs supplied by the server or not</td>
+ *     </tr>
+ *     <tr>
+ *         <td>trustAllHostnames</td>
+ *         <td>false</td>
+ *         <td>Whether we should trust all hostnames supplied by the server or not</td>
+ *     </tr>
+ *     <tr>
  *         <td>tags</td>
  *         <td><i>None</i></td>
  *         <td>tags for all metrics reported to InfluxDb.</td>
@@ -164,6 +174,12 @@ public class InfluxDbReporterFactory extends BaseReporterFactory {
 
     @NotNull
     private String prefix = "";
+    
+    @NotNull
+    private Boolean trustAllCerts = false;
+    
+    @NotNull
+    private Boolean trustAllHostnames = false;
 
     @NotNull
     private Map<String, String> tags = new HashMap<>();
@@ -282,6 +298,26 @@ public class InfluxDbReporterFactory extends BaseReporterFactory {
     @JsonProperty
     public void setPrefix(String prefix) {
         this.prefix = prefix;
+    }
+    
+    @JsonProperty
+    public Boolean isTrustAllCerts(Boolean trustAllCerts) {
+    	return this.trustAllCerts;
+    }
+    
+    @JsonProperty
+    public void setTrustAllCerts(Boolean trustAllCerts) {
+    	this.trustAllCerts = trustAllCerts;
+    }
+    
+    @JsonProperty
+    public Boolean isTrustAllHostnames(Boolean trustAllHostnames) {
+    	return this.trustAllHostnames;
+    }
+    
+    @JsonProperty
+    public void setTrustAllHostnames(Boolean trustAllHostnames) {
+    	this.trustAllHostnames = trustAllHostnames;
     }
 
     @JsonProperty
@@ -433,7 +469,9 @@ public class InfluxDbReporterFactory extends BaseReporterFactory {
                             precision.getUnit(),
                             connectTimeout,
                             readTimeout,
-                            prefix
+                            prefix,
+                            trustAllCerts,
+                            trustAllHostnames
                         )
                     );
                 case TCP:

--- a/dropwizard-metrics-influxdb/src/test/java/com/izettle/metrics/dw/InfluxDbReporterFactoryTest.java
+++ b/dropwizard-metrics-influxdb/src/test/java/com/izettle/metrics/dw/InfluxDbReporterFactoryTest.java
@@ -2,6 +2,8 @@ package com.izettle.metrics.dw;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -151,6 +153,18 @@ public class InfluxDbReporterFactoryTest {
 
         assertThat(getField(influxDb, InfluxDbHttpSender.class, "connectTimeout")).isEqualTo(2000);
         assertThat(getField(influxDb, InfluxDbHttpSender.class, "readTimeout")).isEqualTo(3000);
+    }
+    
+    @Test
+    public void shouldChangeTrusts() throws Exception {
+        factory.setTrustAllCerts(true);
+        assertTrue(factory.isTrustAllCerts());
+        factory.setTrustAllHostnames(true);
+        assertTrue(factory.isTrustAllHostnames());
+        factory.setTrustAllCerts(false);
+        assertFalse(factory.isTrustAllCerts());
+        factory.setTrustAllHostnames(false);
+        assertFalse(factory.isTrustAllHostnames());
     }
 
     @Test

--- a/findbugs/excludes.xml
+++ b/findbugs/excludes.xml
@@ -7,11 +7,11 @@
       <Bug pattern="UNENCRYPTED_SOCKET" />
     </Match>
     <Match>
-      <Class name="com.izettle.metrics.influxdb.InfluxDbHttpSender.TrustingX509TrustManager" />
+      <Package name="com.izettle.metrics.influxdb" />
       <Bug pattern="WEAK_TRUST_MANAGER" />
     </Match>
     <Match>
-      <Class name="com.izettle.metrics.influxdb.InfluxDbHttpSender.TrustingHostNameVerifier" />
+      <Package name="com.izettle.metrics.influxdb" />
       <Bug pattern="WEAK_HOSTNAME_VERIFIER" />
     </Match>
 </FindBugsFilter>

--- a/findbugs/excludes.xml
+++ b/findbugs/excludes.xml
@@ -6,4 +6,12 @@
       <Class name="com.izettle.metrics.influxdb.InfluxDbTcpSender" />
       <Bug pattern="UNENCRYPTED_SOCKET" />
     </Match>
+    <Match>
+      <Class name="com.izettle.metrics.influxdb.InfluxDbHttpSender" />
+      <Bug pattern="WEAK_TRUST_MANAGER" />
+    </Match>
+    <Match>
+      <Class name="com.izettle.metrics.influxdb.InfluxDbHttpSender" />
+      <Bug pattern="WEAK_HOSTNAME_VERIFIER" />
+    </Match>
 </FindBugsFilter>

--- a/findbugs/excludes.xml
+++ b/findbugs/excludes.xml
@@ -11,7 +11,6 @@
       <Bug pattern="WEAK_TRUST_MANAGER" />
     </Match>
     <Match>
-      <Class name="com.izettle.metrics.influxdb.InfluxDbHttpSender" />
       <Bug pattern="WEAK_HOSTNAME_VERIFIER" />
     </Match>
 </FindBugsFilter>

--- a/findbugs/excludes.xml
+++ b/findbugs/excludes.xml
@@ -7,10 +7,11 @@
       <Bug pattern="UNENCRYPTED_SOCKET" />
     </Match>
     <Match>
-      <Class name="com.izettle.metrics.influxdb.InfluxDbHttpSender" />
+      <Class name="com.izettle.metrics.influxdb.InfluxDbHttpSender.TrustingX509TrustManager" />
       <Bug pattern="WEAK_TRUST_MANAGER" />
     </Match>
     <Match>
+      <Class name="com.izettle.metrics.influxdb.InfluxDbHttpSender.TrustingHostNameVerifier" />
       <Bug pattern="WEAK_HOSTNAME_VERIFIER" />
     </Match>
 </FindBugsFilter>

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
@@ -6,7 +6,19 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
 import org.apache.commons.codec.binary.Base64;
 
 /**
@@ -14,79 +26,145 @@ import org.apache.commons.codec.binary.Base64;
  */
 public class InfluxDbHttpSender extends InfluxDbBaseSender {
 
-    private final URL url;
-    // The base64 encoded authString.
-    private final String authStringEncoded;
-    private final int connectTimeout;
-    private final int readTimeout;
+	private final URL url;
+	// The base64 encoded authString.
+	private final String authStringEncoded;
+	private final int connectTimeout;
+	private final int readTimeout;
 
-    /**
-     * Creates a new http sender given connection details.
-     *
-     * @param hostname        the influxDb hostname
-     * @param port            the influxDb http port
-     * @param database        the influxDb database to write to
-     * @param authString      the authorization string to be used to connect to InfluxDb, of format username:password
-     * @param timePrecision   the time precision of the metrics
-     * @param connectTimeout  the connect timeout
-     * @param connectTimeout  the read timeout
-     * @throws Exception exception while creating the influxDb sender(MalformedURLException)
-     */
-    public InfluxDbHttpSender(
-        final String protocol, final String hostname, final int port, final String database, final String authString,
-        final TimeUnit timePrecision, final int connectTimeout, final int readTimeout, final String measurementPrefix)
-        throws Exception {
-        super(database, timePrecision, measurementPrefix);
+	/**
+	 * Creates a new http sender given connection details.
+	 *
+	 * @param hostname
+	 *            the influxDb hostname
+	 * @param port
+	 *            the influxDb http port
+	 * @param database
+	 *            the influxDb database to write to
+	 * @param authString
+	 *            the authorization string to be used to connect to InfluxDb, of
+	 *            format username:password
+	 * @param timePrecision
+	 *            the time precision of the metrics
+	 * @param connectTimeout
+	 *            the connect timeout
+	 * @param connectTimeout
+	 *            the read timeout
+	 * @param trustAllCerts
+	 *            whether all certs should be trusted or not
+	 * @param trustAllHostnames
+	 *            whether all hostnames should be trusted or not
+	 * @throws Exception
+	 *             exception while creating the influxDb
+	 *             sender(MalformedURLException)
+	 */
+	public InfluxDbHttpSender(final String protocol, final String hostname, final int port, final String database,
+			final String authString, final TimeUnit timePrecision, final int connectTimeout, final int readTimeout,
+			final String measurementPrefix, boolean trustAllCerts, boolean trustAllHostnames) throws Exception {
+		super(database, timePrecision, measurementPrefix);
+		updateSecurity(trustAllCerts, trustAllHostnames);
+		String endpoint = new URL(protocol, hostname, port, "/write").toString();
+		String queryDb = String.format("db=%s", URLEncoder.encode(database, "UTF-8"));
+		String queryPrecision = String.format("precision=%s", TimeUtils.toTimePrecision(timePrecision));
+		this.url = new URL(endpoint + "?" + queryDb + "&" + queryPrecision);
 
-        String endpoint = new URL(protocol, hostname, port, "/write").toString();
-        String queryDb = String.format("db=%s", URLEncoder.encode(database, "UTF-8"));
-        String queryPrecision = String.format("precision=%s", TimeUtils.toTimePrecision(timePrecision));
-        this.url = new URL(endpoint + "?" + queryDb + "&" + queryPrecision);
+		if (authString != null && !authString.isEmpty()) {
+			this.authStringEncoded = Base64.encodeBase64String(authString.getBytes(UTF_8));
+		} else {
+			this.authStringEncoded = "";
+		}
 
-        if (authString != null && !authString.isEmpty()) {
-            this.authStringEncoded = Base64.encodeBase64String(authString.getBytes(UTF_8));
-        } else {
-            this.authStringEncoded = "";
-        }
+		this.connectTimeout = connectTimeout;
+		this.readTimeout = readTimeout;
+	}
 
-        this.connectTimeout = connectTimeout;
-        this.readTimeout = readTimeout;
-    }
+	private void updateSecurity(boolean trustAllCerts, boolean trustAllHostnames)
+			throws NoSuchAlgorithmException, KeyManagementException {
+		updateCertTrust(trustAllCerts);
+		updateHostnameTrust(trustAllHostnames);
+	}
 
-    @Deprecated
-    public InfluxDbHttpSender(
-        final String protocol, final String hostname, final int port, final String database, final String authString,
-        final TimeUnit timePrecision) throws Exception {
-        this(protocol, hostname, port, database, authString, timePrecision, 1000, 1000, "");
-    }
+	private void updateHostnameTrust(boolean trusting) {
+		if (trusting) {
+			// Create all-trusting host name verifier
+			HostnameVerifier allHostsValid = new HostnameVerifier() {
+				public boolean verify(String hostname, SSLSession session) {
+					return true;
+				}
+			};
 
-    @Override
-    protected int writeData(byte[] line) throws Exception {
-        final HttpURLConnection con = (HttpURLConnection) url.openConnection();
-        con.setRequestMethod("POST");
-        if (authStringEncoded != null && !authStringEncoded.isEmpty()) {
-            con.setRequestProperty("Authorization", "Basic " + authStringEncoded);
-        }
-        con.setDoOutput(true);
-        con.setConnectTimeout(connectTimeout);
-        con.setReadTimeout(readTimeout);
+			// Install the all-trusting host verifier
+			HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
+		}
+	}
 
-        OutputStream out = con.getOutputStream();
-        try {
-            out.write(line);
-            out.flush();
-        } finally {
-            out.close();
-        }
+	private void updateCertTrust(boolean trusting) throws NoSuchAlgorithmException, KeyManagementException {
+		if (trusting) {
+			// Create a trust manager that does not validate certificate chains
+			TrustManager[] trustAllCerts = new TrustManager[] { new X509TrustManager() {
 
-        int responseCode = con.getResponseCode();
+				@Override
+				public void checkClientTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
+				}
 
-        // Check if non 2XX response code.
-        if (responseCode / 100 != 2) {
-            throw new IOException(
-                "Server returned HTTP response code: " + responseCode + " for URL: " + url + " with content :'"
-                    + con.getResponseMessage() + "'");
-        }
-        return responseCode;
-    }
+				@Override
+				public void checkServerTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
+				}
+
+				@Override
+				public X509Certificate[] getAcceptedIssuers() {
+					return null;
+				}
+
+			} };
+
+			// Install the all-trusting trust manager
+			SSLContext sc = SSLContext.getInstance("SSL");
+			sc.init(null, trustAllCerts, new java.security.SecureRandom());
+			HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+		}
+	}
+
+	@Deprecated
+	public InfluxDbHttpSender(final String protocol, final String hostname, final int port, final String database,
+			final String authString, final TimeUnit timePrecision, final int connectTimeout, final int readTimeout,
+			final String measurementPrefix) throws Exception {
+		this(protocol, hostname, port, database, authString, timePrecision, connectTimeout, readTimeout,
+				measurementPrefix, false, false);
+	}
+
+	@Deprecated
+	public InfluxDbHttpSender(final String protocol, final String hostname, final int port, final String database,
+			final String authString, final TimeUnit timePrecision) throws Exception {
+		this(protocol, hostname, port, database, authString, timePrecision, 1000, 1000, "");
+	}
+
+	@Override
+	protected int writeData(byte[] line) throws Exception {
+		final HttpURLConnection con = (HttpURLConnection) url.openConnection();
+		con.setRequestMethod("POST");
+		if (authStringEncoded != null && !authStringEncoded.isEmpty()) {
+			con.setRequestProperty("Authorization", "Basic " + authStringEncoded);
+		}
+		con.setDoOutput(true);
+		con.setConnectTimeout(connectTimeout);
+		con.setReadTimeout(readTimeout);
+
+		OutputStream out = con.getOutputStream();
+		try {
+			out.write(line);
+			out.flush();
+		} finally {
+			out.close();
+		}
+
+		int responseCode = con.getResponseCode();
+
+		// Check if non 2XX response code.
+		if (responseCode / 100 != 2) {
+			throw new IOException("Server returned HTTP response code: " + responseCode + " for URL: " + url
+					+ " with content :'" + con.getResponseMessage() + "'");
+		}
+		return responseCode;
+	}
 }

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
@@ -119,7 +119,7 @@ public class InfluxDbHttpSender extends InfluxDbBaseSender {
 			} };
 
 			// Install the all-trusting trust manager
-			SSLContext sc = SSLContext.getInstance("SSL");
+			SSLContext sc = SSLContext.getInstance("TLS");
 			sc.init(null, trustAllCerts, new java.security.SecureRandom());
 			HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
 		}

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
@@ -84,17 +84,19 @@ public class InfluxDbHttpSender extends InfluxDbBaseSender {
 		updateHostnameTrust(trustAllHostnames);
 	}
 
+	public static class TrustingHostNameVerifier implements HostnameVerifier {
+
+		@Override
+		public boolean verify(String hostname, SSLSession session) {
+			return true;
+		}
+
+	}
+
 	private void updateHostnameTrust(boolean trusting) {
 		if (trusting) {
-			// Create all-trusting host name verifier
-			HostnameVerifier allHostsValid = new HostnameVerifier() {
-				public boolean verify(String hostname, SSLSession session) {
-					return true;
-				}
-			};
-
 			// Install the all-trusting host verifier
-			HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
+			HttpsURLConnection.setDefaultHostnameVerifier(new TrustingHostNameVerifier());
 		}
 	}
 

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
@@ -51,9 +51,9 @@ public class InfluxDbHttpSender extends InfluxDbBaseSender {
 	 * @param connectTimeout
 	 *            the read timeout
 	 * @param trustAllCerts
-	 *            whether all certs should be trusted or not
+	 *            whether all certs should be trusted or not (setting this to true may expose you to MITM attacks)
 	 * @param trustAllHostnames
-	 *            whether all hostnames should be trusted or not
+	 *            whether all hostnames should be trusted or not (setting this to true may expose you to MITM attacks)
 	 * @throws Exception
 	 *             exception while creating the influxDb
 	 *             sender(MalformedURLException)
@@ -99,26 +99,28 @@ public class InfluxDbHttpSender extends InfluxDbBaseSender {
 			HttpsURLConnection.setDefaultHostnameVerifier(new TrustingHostNameVerifier());
 		}
 	}
+	
+	public static class TrustingX509TrustManager implements X509TrustManager {
+
+		@Override
+		public void checkClientTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
+		}
+
+		@Override
+		public void checkServerTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
+		}
+
+		@Override
+		public X509Certificate[] getAcceptedIssuers() {
+			return new X509Certificate[] {};
+		}
+		
+	}
 
 	private void updateCertTrust(boolean trusting) throws NoSuchAlgorithmException, KeyManagementException {
 		if (trusting) {
 			// Create a trust manager that does not validate certificate chains
-			TrustManager[] trustAllCerts = new TrustManager[] { new X509TrustManager() {
-
-				@Override
-				public void checkClientTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
-				}
-
-				@Override
-				public void checkServerTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
-				}
-
-				@Override
-				public X509Certificate[] getAcceptedIssuers() {
-					return null;
-				}
-
-			} };
+			TrustManager[] trustAllCerts = new TrustManager[] { new TrustingX509TrustManager() };
 
 			// Install the all-trusting trust manager
 			SSLContext sc = SSLContext.getInstance("TLS");

--- a/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/InfluxDbHttpSenderTest.java
+++ b/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/InfluxDbHttpSenderTest.java
@@ -34,10 +34,7 @@ public class InfluxDbHttpSenderTest {
             80,
             "testdb",
             "asdf",
-            TimeUnit.MINUTES,
-            1000,
-            1000,
-            ""
+            TimeUnit.MINUTES
         );
         influxDbHttpSender.writeData(new byte[0]);
     }

--- a/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/InfluxDbHttpSenderTest.java
+++ b/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/InfluxDbHttpSenderTest.java
@@ -53,7 +53,9 @@ public class InfluxDbHttpSenderTest {
             TimeUnit.MINUTES,
             0,
             0,
-            ""
+            "",
+            true,
+            true
         );
         influxDbHttpSender.writeData(new byte[0]);
     }

--- a/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/InfluxDbHttpSenderTest.java
+++ b/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/InfluxDbHttpSenderTest.java
@@ -51,8 +51,8 @@ public class InfluxDbHttpSenderTest {
             "testdb",
             "asdf",
             TimeUnit.MINUTES,
-            1000,
-            1000,
+            0,
+            0,
             ""
         );
         influxDbHttpSender.writeData(new byte[0]);

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
                     <threshold>Low</threshold>
                     <xmlOutput>true</xmlOutput>
                     <failOnError>true</failOnError>
-                    <excludeFilterFile>${session.executionRootDirectory}/findbugs/verifyexcludes.xml</excludeFilterFile>
+                    <excludeFilterFile>${session.executionRootDirectory}/findbugs/excludes.xml</excludeFilterFile>
                     <plugins>
                         <!-- Add the security plugin from http://find-sec-bugs.github.io/ -->
                         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
                     <threshold>Low</threshold>
                     <xmlOutput>true</xmlOutput>
                     <failOnError>true</failOnError>
-                    <excludeFilterFile>${session.executionRootDirectory}/findbugs/excludes.xml</excludeFilterFile>
+                    <excludeFilterFile>${session.executionRootDirectory}/findbugs/verifyexcludes.xml</excludeFilterFile>
                     <plugins>
                         <!-- Add the security plugin from http://find-sec-bugs.github.io/ -->
                         <plugin>


### PR DESCRIPTION
Hey,

While using this repo on-prem and trying to get https to work (I write both the server and the client, and was trying to self-sign certificates while our CA was unavailable), I encountered the following issue:
When influxdb is using an unsecure certificate (for example, if the CA that signed it is not trusted), InfluxDbHttpSender cannot send metrics to influxdb (client will refuse to connect to an untrusted influxdb).

While I agree this default behavior sounds like a good choice, I wanted to allow unsecure https for the sake of https integration when a CA is unavailable.

I made the changes in my own fork (on-prem) but thought it may be nice to port them back to the community.