### PR TITLE
Add support for skipping idle counters

### DIFF
--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbReporter.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbReporter.java
@@ -395,6 +395,9 @@ public final class InfluxDbReporter extends ScheduledReporter {
     }
 
     private void reportCounter(String name, Counter counter, long now) {
+        if (canSkipMetric(name, counter)) {
+            return;
+        }
         Map<String, Object> fields = new HashMap<String, Object>();
         fields.put("count", counter.getCount());
 


### PR DESCRIPTION
This is the same issue as reported in #78. For some reason, idle counters still get reported. It would be nice if we could not send anything from the client during its idle period.