### PR TITLE
Bump versions of Kafka and Dropwizard to avoid CVE errors

### DIFF
--- a/metrics-influxdb/pom.xml
+++ b/metrics-influxdb/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>1.1.0</version>
+            <version>2.3.0</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     </modules>
 
     <properties>
-        <dropwizard.version>1.3.8</dropwizard.version>
+        <dropwizard.version>1.3.12</dropwizard.version>
         <mockito.version>2.23.4</mockito.version>
     </properties>
 


### PR DESCRIPTION
This seems to block many of our repos to build, including Sun. 