### PR TITLE
Bump Dropwizard to 1.3.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     </modules>
 
     <properties>
-        <dropwizard.version>1.3.14</dropwizard.version>
+        <dropwizard.version>1.3.17</dropwizard.version>
         <mockito.version>3.0.0</mockito.version>
     </properties>
 


### PR DESCRIPTION
Bump Dropwizard to 1.3.17 to get version updates of included libraries.