### PR TITLE
Allow grouping all measurements into one with multiple fields

### DIFF
--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSender.java
@@ -6,12 +6,100 @@ import com.izettle.metrics.influxdb.data.InfluxDbWriteObject;
 import com.izettle.metrics.influxdb.utils.InfluxDbWriteObjectSerializer;
 
 /**
- *  Passthrough to ultimately select a different style of serializer: grouped fields on one influxdb protocol line,
- *  instead of one field per protocol line.
+ * Passthrough to ultimately select a different style of serializer: grouped fields on one influxdb protocol line, instead of one field per
+ * protocol line.
+ * 
+ * This class will write out one protocol line per timestamp. For each point that occurred at a particular timestamp, a line is output in
+ * the following order with commas delimiting each of the first three items and then a space before the timestamp:
+ * 1. measurementPrefix+groupMeasurement
+ * 2. tags (in the format of name=value) delimited by commas
+ * 3. each field is written prepended with a name that indicates its measurement delimited by commas. There is an assumption made here that
+ *    the measurement naming convention is a set of strings delimited by a ".". In the case where there is at least two strings in the
+ *    measurement name, the first string in that name is dropped. Also, if a particular point has only one field and that field has the key
+ *    "value", the field name is dropped.
+ * 4. time (in milliseconds)
+ * 
+ * To illustrate what is described above, here are some examples of what will be written for some sets of points.
+ * 
+ * <h3>EXAMPLE</h3>
+ * <pre>
+ * [
+ *   // The first two points are intended to show how points with the same timestamp are merged.
+ *   Point {
+ *     measurement: confabulator.a.b.c,
+ *     tags {
+ *       foo: one,
+ *       bar: two
+ *     },
+ *     time: 0,
+ *     fields {
+ *       temp: 10,
+ *       bytes: 7
+ *     }
+ *   },
+ *   Point {
+ *     measurement: confabulator.x.y.z,
+ *     tags {
+ *       foo: one,
+ *       bar: two
+ *     },
+ *     time: 0,
+ *     fields {
+ *       pressure: 50,
+ *       status: good
+ *     }
+ *   },
+ *   // This next point shows the example of when the field has one key called "value"
+ *   Point {
+ *     measurement: confabulator.file.size.max,
+ *     tags {},
+ *     time: 1,
+ *     fields {
+ *       value = 10000000
+ *     }
+ *   },
+ *   // This next point shows an example of what is written when measurement is only a single string
+ *   Point {
+ *     measurement: minimum,
+ *     tags {},
+ *     time: 2,
+ *     fields {
+ *       memory: 64000,
+ *       temperature: 98.6
+ *     }
+ *   }
+ * ]
+ * </pre>
+ * 
+ * <h3>OUTPUT FOR ABOVE EXAMPLE</h3>
+ * Assuming that the value for the <code>measurementPrefix</code> is <code>null</code> and the <code>groupMeasurement</code> is the string
+ * "groupMeasurement", the output for the above example would result in three lines corresponding to the three unique timestamps. The lines
+ * would be as follows:
+ * <pre>
+ * groupMeasurement,foo=one,bar=two,a.b.c.temp=10,a.b.c.bytes=7,x.y.z.pressure=50,x.y.z.status=good 0
+ * groupMeasurement,file.size.max=10000000 1
+ * groupMeasurement,minimum.memory=64000,minimum.temperature=98.6 2
+ * </pre>
  */
 public class GroupedInfluxDbHttpSender extends InfluxDbHttpSender {
     private final String groupMeasurement;
     
+    /**
+     * Creates a new http sender given connection details. This sender groups all the fields under one measurement and transmit them as one
+     * measurement.
+     * 
+     * @param protocol           the name of the protocol to use
+     * @param hostname           the influxDb hostname
+     * @param port               the influxDb http port
+     * @param database           the influxDb database to write to
+     * @param authString         the authorization string to be used to connect to InfluxDb, of format username:password
+     * @param timePrecision      the time precision of the metrics
+     * @param connectTimeout     the connect timeout
+     * @param readTimeout        the read timeout
+     * @param measurementPrefix  the measurement prefix
+     * @param groupMeasurement   the group measurement name
+     * @throws Exception exception while creating the influxDb sender(MalformedURLException)
+     */
     public GroupedInfluxDbHttpSender(String protocol, String hostname, int port, String database, String authString,
             TimeUnit timePrecision, int connectTimeout, int readTimeout, String measurementPrefix, String groupMeasurement) throws Exception {
         super(protocol, hostname, port, database, authString, timePrecision, connectTimeout, readTimeout, measurementPrefix);

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSender.java
@@ -10,7 +10,7 @@ import com.izettle.metrics.influxdb.utils.InfluxDbWriteObjectSerializer;
  * protocol line.
  * 
  * This class will write out one protocol line per timestamp. For each point that occurred at a particular timestamp, a line is output in
- * the following order with commas delimiting each of the first three items and then a space before the timestamp:
+ * the following order with a comma delimiting the first two items and a space delimiting all other items:
  * 1. measurementPrefix+groupMeasurement
  * 2. tags (in the format of name=value) delimited by commas
  * 3. each field is written prepended with a name that indicates its measurement delimited by commas. There is an assumption made here that
@@ -76,9 +76,9 @@ import com.izettle.metrics.influxdb.utils.InfluxDbWriteObjectSerializer;
  * "groupMeasurement", the output for the above example would result in three lines corresponding to the three unique timestamps. The lines
  * would be as follows:
  * <pre>
- * groupMeasurement,foo=one,bar=two,a.b.c.temp=10,a.b.c.bytes=7,x.y.z.pressure=50,x.y.z.status=good 0
- * groupMeasurement,file.size.max=10000000 1
- * groupMeasurement,minimum.memory=64000,minimum.temperature=98.6 2
+ * groupMeasurement,foo=one,bar=two a.b.c.temp=10,a.b.c.bytes=7,x.y.z.pressure=50,x.y.z.status=good 0
+ * groupMeasurement file.size.max=10000000 1
+ * groupMeasurement minimum.memory=64000,minimum.temperature=98.6 2
  * </pre>
  */
 public class GroupedInfluxDbHttpSender extends InfluxDbHttpSender {

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSender.java
@@ -1,0 +1,29 @@
+package com.izettle.metrics.influxdb;
+
+import java.util.concurrent.TimeUnit;
+
+import com.izettle.metrics.influxdb.data.InfluxDbWriteObject;
+import com.izettle.metrics.influxdb.utils.InfluxDbWriteObjectSerializer;
+
+/**
+ *  Passthrough to ultimately select a different style of serializer: grouped fields on one influxdb protocol line,
+ *  instead of one field per protocol line.
+ */
+public class GroupedInfluxDbHttpSender extends InfluxDbHttpSender {
+    private final String groupMeasurement;
+    
+    public GroupedInfluxDbHttpSender(String protocol, String hostname, int port, String database, String authString,
+            TimeUnit timePrecision, int connectTimeout, int readTimeout, String measurementPrefix, String groupMeasurement) throws Exception {
+        super(protocol, hostname, port, database, authString, timePrecision, connectTimeout, readTimeout, measurementPrefix);
+        this.groupMeasurement = groupMeasurement;
+    }
+
+    @Override
+    public int writeData() throws Exception {
+        InfluxDbWriteObjectSerializer serializer = this.getSerializer();
+        InfluxDbWriteObject writeObject = this.getWriteObject();
+        String linestr = serializer.getGroupedLineProtocolString(writeObject, groupMeasurement);
+        final byte[] line = linestr.getBytes(UTF_8);
+        return super.writeData(line);
+    }
+}

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSender.java
@@ -52,7 +52,10 @@ import com.izettle.metrics.influxdb.utils.InfluxDbWriteObjectSerializer;
  *   // This next point shows the example of when the field has one key called "value"
  *   Point {
  *     measurement: confabulator.file.size.max,
- *     tags {},
+ *     tags {
+ *       foo: one,
+ *       bar: two
+ *     },
  *     time: 1,
  *     fields {
  *       value = 10000000
@@ -61,7 +64,10 @@ import com.izettle.metrics.influxdb.utils.InfluxDbWriteObjectSerializer;
  *   // This next point shows an example of what is written when measurement is only a single string
  *   Point {
  *     measurement: minimum,
- *     tags {},
+ *     tags {
+ *       foo: one,
+ *       bar: two
+ *     },
  *     time: 2,
  *     fields {
  *       memory: 64000,
@@ -77,8 +83,8 @@ import com.izettle.metrics.influxdb.utils.InfluxDbWriteObjectSerializer;
  * would be as follows:
  * <pre>
  * groupMeasurement,foo=one,bar=two a.b.c.temp=10,a.b.c.bytes=7,x.y.z.pressure=50,x.y.z.status=good 0
- * groupMeasurement file.size.max=10000000 1
- * groupMeasurement minimum.memory=64000,minimum.temperature=98.6 2
+ * groupMeasurement,foo=one,bar=two file.size.max=10000000 1
+ * groupMeasurement,foo=one,bar=two minimum.memory=64000,minimum.temperature=98.6 2
  * </pre>
  */
 public class GroupedInfluxDbHttpSender extends InfluxDbHttpSender {

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSender.java
@@ -19,7 +19,7 @@ import com.izettle.metrics.influxdb.utils.InfluxDbWriteObjectSerializer;
  *    "value", the field name is dropped.
  * 4. time (in milliseconds)
  * 
- * To illustrate what is described above, here are some examples of what will be written for some sets of points.
+ * To illustrate what is described above, here is an examples of what will be written for a given sets of points.
  * 
  * <h3>EXAMPLE</h3>
  * <pre>

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbBaseSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbBaseSender.java
@@ -41,7 +41,8 @@ abstract class InfluxDbBaseSender implements InfluxDbSender {
 
     @Override
     public int writeData() throws Exception {
-        final byte[] line = influxDbWriteObjectSerializer.getLineProtocolString(influxDbWriteObject).getBytes(UTF_8);
+        String linestr = influxDbWriteObjectSerializer.getLineProtocolString(influxDbWriteObject);
+        final byte[] line = linestr.getBytes(UTF_8);
 
         return writeData(line);
     }
@@ -58,5 +59,13 @@ abstract class InfluxDbBaseSender implements InfluxDbSender {
     @Override
     public Map<String, String> getTags() {
         return influxDbWriteObject.getTags();
+    }
+
+    protected InfluxDbWriteObject getWriteObject() {
+        return this.influxDbWriteObject;
+    }
+
+    protected InfluxDbWriteObjectSerializer getSerializer() {
+        return this.influxDbWriteObjectSerializer;
     }
 }

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
@@ -23,14 +23,13 @@ public class InfluxDbHttpSender extends InfluxDbBaseSender {
     /**
      * Creates a new http sender given connection details.
      *
-     * @param protocol           the name of the protocol to use
-     * @param hostname           the influxDb hostname
-     * @param port               the influxDb http port
-     * @param database           the influxDb database to write to
-     * @param authString         the authorization string to be used to connect to InfluxDb, of format username:password
-     * @param timePrecision      the time precision of the metrics
-     * @param connectTimeout     the connect timeout
-     * @param readTimeout        the read timeout
+     * @param hostname        the influxDb hostname
+     * @param port            the influxDb http port
+     * @param database        the influxDb database to write to
+     * @param authString      the authorization string to be used to connect to InfluxDb, of format username:password
+     * @param timePrecision   the time precision of the metrics
+     * @param connectTimeout  the connect timeout
+     * @param connectTimeout  the read timeout
      * @throws Exception exception while creating the influxDb sender(MalformedURLException)
      */
     public InfluxDbHttpSender(

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/InfluxDbHttpSender.java
@@ -23,13 +23,14 @@ public class InfluxDbHttpSender extends InfluxDbBaseSender {
     /**
      * Creates a new http sender given connection details.
      *
-     * @param hostname        the influxDb hostname
-     * @param port            the influxDb http port
-     * @param database        the influxDb database to write to
-     * @param authString      the authorization string to be used to connect to InfluxDb, of format username:password
-     * @param timePrecision   the time precision of the metrics
-     * @param connectTimeout  the connect timeout
-     * @param connectTimeout  the read timeout
+     * @param protocol           the name of the protocol to use
+     * @param hostname           the influxDb hostname
+     * @param port               the influxDb http port
+     * @param database           the influxDb database to write to
+     * @param authString         the authorization string to be used to connect to InfluxDb, of format username:password
+     * @param timePrecision      the time precision of the metrics
+     * @param connectTimeout     the connect timeout
+     * @param readTimeout        the read timeout
      * @throws Exception exception while creating the influxDb sender(MalformedURLException)
      */
     public InfluxDbHttpSender(

--- a/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/utils/InfluxDbWriteObjectSerializer.java
+++ b/metrics-influxdb/src/main/java/com/izettle/metrics/influxdb/utils/InfluxDbWriteObjectSerializer.java
@@ -3,6 +3,8 @@ package com.izettle.metrics.influxdb.utils;
 import com.izettle.metrics.influxdb.data.InfluxDbPoint;
 import com.izettle.metrics.influxdb.data.InfluxDbWriteObject;
 import java.text.NumberFormat;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -14,6 +16,7 @@ public class InfluxDbWriteObjectSerializer {
     private static final Pattern SPACE = Pattern.compile(" ");
     private static final Pattern EQUAL = Pattern.compile("=");
     private static final Pattern DOUBLE_QUOTE = Pattern.compile("\"");
+    private static final Pattern FIELD = Pattern.compile("\\.");
     private final String measurementPrefix;
 
     public InfluxDbWriteObjectSerializer(String measurementPrefix) {
@@ -30,17 +33,94 @@ public class InfluxDbWriteObjectSerializer {
     public String getLineProtocolString(InfluxDbWriteObject influxDbWriteObject) {
         StringBuilder stringBuilder = new StringBuilder();
         for (InfluxDbPoint point : influxDbWriteObject.getPoints()) {
-            lineProtocol(point, influxDbWriteObject.getPrecision(), stringBuilder);
+            pointLineProtocol(point, influxDbWriteObject.getPrecision(), stringBuilder);
             stringBuilder.append("\n");
         }
         return stringBuilder.toString();
     }
 
-    private void lineProtocol(InfluxDbPoint point, TimeUnit precision, StringBuilder stringBuilder) {
-        stringBuilder.append(escapeMeasurement(measurementPrefix+point.getMeasurement()));
-        concatenatedTags(point.getTags(), stringBuilder);
-        concatenateFields(point.getFields(), stringBuilder);
-        formattedTime(point.getTime(), precision, stringBuilder);
+    /**
+     * calculate the line protocol for all Points - grouped with same tags and timestamp. The realMeasurement
+     * is what's going to be common for all measurements on the line.
+     *
+     * @return the String with newLines.
+     */
+    public String getGroupedLineProtocolString(InfluxDbWriteObject influxDbWriteObject, String realMeasurement) {
+        // First develop a set of timestamps.
+        HashSet<Long> times = new HashSet<>();
+        for (InfluxDbPoint point : influxDbWriteObject.getPoints()) {
+            times.add(point.getTime());
+        }
+
+        // Write lines, one per timestamp, instead of one per point.  Collect tags from one point
+        // as all are presumed the same.
+        StringBuilder stringBuilder = new StringBuilder();
+        for (Long time : times) {
+            Map<String, Object> fields = new HashMap<>();
+            Map<String, String> tags = null;
+            
+            for (InfluxDbPoint point : influxDbWriteObject.getPoints()) {
+                if (point.getTime().equals(time)) {
+                    mergeFields(fields, point.getFields(), point.getMeasurement());
+                    tags = point.getTags();
+                }
+            }
+            lineProtocol(tags, fields, realMeasurement, time, influxDbWriteObject.getPrecision(),
+                    stringBuilder);
+            stringBuilder.append("\n");
+        }
+
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Merge fields, also parsing up the field name.
+     *
+     * Rip off the first "." element from the measurement, then prepend measurement to all field keys.
+     * This is an ASSUMPTION of the user's naming convention, because they're using this feature. This
+     * is acknowledged evil based on the current design.
+     *
+     *  Eg src:  {temp=10,bytes=7}, measurement: confabulator.a.b.c
+     *     dest: {confabulator.a.b.c.temp=10,confabulator.a.b.c.bytes=7}
+     *
+     * In the specific case where there is ONE field and its key is "value" (ie, the JVM gauge group),
+     * there is no need for its postfixed ".value" on everything, so we drop it.  Another ASSUMPTION.
+     * TODO: (?) configurable?
+     *
+     *  Eg src:  {value=10}, measurement: confabulator.jvm.memory_usage.pools.Code-Cache.max
+     *     dest: {jvm.memory_usage.pools.Code-Cache.max=10}
+     */
+    private void mergeFields(Map<String, Object> dest, Map<String, Object> src, String measurement) {
+        String[] words = FIELD.split(measurement, 2);
+        String tail;
+
+        if (words.length == 2) {
+            tail = words[1];
+        } else {
+            tail = measurement;
+        }
+
+        for (Map.Entry<String, Object> field : src.entrySet()) {
+            if (src.entrySet().size() == 1 && field.getKey().equals("value")) {
+                dest.put(tail, field.getValue());
+            }
+            else {
+                dest.put(tail + "." + field.getKey(), field.getValue());
+            }
+        }
+    }
+
+    private void pointLineProtocol(InfluxDbPoint point, TimeUnit precision, StringBuilder stringBuilder) {
+        lineProtocol(point.getTags(), point.getFields(), point.getMeasurement(), point.getTime(),
+                precision, stringBuilder);
+    }
+
+    private void lineProtocol(Map<String, String> tags, Map<String, Object> fields,
+            String measurement, Long time, TimeUnit precision, StringBuilder stringBuilder) {
+        stringBuilder.append(escapeMeasurement(measurementPrefix + measurement));
+        concatenatedTags(tags, stringBuilder);
+        concatenateFields(fields, stringBuilder);
+        formattedTime(time, precision, stringBuilder);
     }
 
     private void concatenatedTags(Map<String, String> tags, StringBuilder stringBuilder) {

--- a/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSenderTest.java
+++ b/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/GroupedInfluxDbHttpSenderTest.java
@@ -1,0 +1,60 @@
+package com.izettle.metrics.influxdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+
+public class GroupedInfluxDbHttpSenderTest {
+
+    static class MyHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange t) throws IOException {
+            String response = "This is the response";
+            t.sendResponseHeaders(200, response.length());
+            OutputStream os = t.getResponseBody();
+            os.write(response.getBytes());
+            os.close();
+        }
+    }
+
+    @Test
+    public void shouldNotThrowException() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress(10085), 0);
+        try {
+            server.createContext("/write", new MyHandler());
+            server.setExecutor(null); // creates a default executor
+            server.start();
+            InfluxDbHttpSender influxDbHttpSender = new GroupedInfluxDbHttpSender(
+                "http",
+                "localhost",
+                10085,
+                "testdb",
+                "asdf",
+                TimeUnit.MINUTES,
+                1000,
+                1000,
+                "",
+                "MyGroup"
+            );
+            assertThat(influxDbHttpSender.getSerializer() != null);
+            assertThat(influxDbHttpSender.getWriteObject() != null);
+            assertThat(influxDbHttpSender.getTags().isEmpty());
+            assertThat(influxDbHttpSender.getWriteObject().getDatabase().equals("testdb"));
+            assertThat(influxDbHttpSender.writeData(new byte[0]) == 0);
+            
+            influxDbHttpSender.flush();
+            
+        } catch (IOException e) {
+            throw new IOException(e);
+        } finally {
+            server.stop(0);
+        }
+    }
+}

--- a/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/utils/InfluxDbWriteObjectSerializerTest.java
+++ b/metrics-influxdb/src/test/java/com/izettle/metrics/influxdb/utils/InfluxDbWriteObjectSerializerTest.java
@@ -41,6 +41,73 @@ public class InfluxDbWriteObjectSerializerTest {
     }
 
     @Test
+    public void shouldSerializeUsingGroupedLineProtocol() {
+        Map<String, String> tags = new HashMap<String, String>();
+        tags.put("tag1Key", "tag1Value");
+        Map<String, Object> fields = new HashMap<String, Object>();
+        fields.put("field1Key", "field1Value");
+        InfluxDbPoint point1 = new InfluxDbPoint("aaa.bbb.ccc", tags, 456l, fields);
+        Set<InfluxDbPoint> set = new HashSet<InfluxDbPoint>();
+        set.add(point1);
+        InfluxDbWriteObject influxDbWriteObject = mock(InfluxDbWriteObject.class);
+        when(influxDbWriteObject.getPoints()).thenReturn(set);
+        when(influxDbWriteObject.getPrecision()).thenReturn(TimeUnit.MICROSECONDS);
+        InfluxDbWriteObjectSerializer influxDbWriteObjectSerializer = new InfluxDbWriteObjectSerializer("");
+        String lineString = influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject, "xxx");
+        assertThat(lineString).isEqualTo(
+                "xxx,tag1Key=tag1Value bbb.ccc.field1Key=\"field1Value\" 456000\n");
+        InfluxDbPoint point2 = new InfluxDbPoint("www.yyy.zzz", tags, 456l, fields);
+        set.add(point2);
+        lineString = influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject, "xxx");
+        assertThat(lineString).isEqualTo(
+                "xxx,tag1Key=tag1Value bbb.ccc.field1Key=\"field1Value\",yyy.zzz.field1Key=\"field1Value\" 456000\n");
+    }
+
+    @Test
+    public void groupedLinesShouldFoldValueFields() {
+        Map<String, String> tags = new HashMap<String, String>();
+        tags.put("tag1Key", "tag1Value");
+        Map<String, Object> fields1 = new HashMap<String, Object>();
+        fields1.put("value", "111");
+        Map<String, Object> fields2 = new HashMap<String, Object>();
+        fields2.put("value", "222");
+        InfluxDbPoint point1 = new InfluxDbPoint("aa.bb.cc1", tags, 456l, fields1);
+        InfluxDbPoint point2 = new InfluxDbPoint("aa.bb.cc2", tags, 456l, fields2);
+        Set<InfluxDbPoint> set = new HashSet<InfluxDbPoint>();
+        set.add(point1);
+        set.add(point2);
+        InfluxDbWriteObject influxDbWriteObject = mock(InfluxDbWriteObject.class);
+        when(influxDbWriteObject.getPoints()).thenReturn(set);
+        when(influxDbWriteObject.getPrecision()).thenReturn(TimeUnit.MICROSECONDS);
+        InfluxDbWriteObjectSerializer influxDbWriteObjectSerializer = new InfluxDbWriteObjectSerializer("");
+        String lineString = influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject, "xxx");
+        assertThat(lineString).isEqualTo("xxx,tag1Key=tag1Value bb.cc2=\"222\",bb.cc1=\"111\" 456000\n");
+    }
+
+    @Test
+    public void undottedMeasurementShouldFallback() {
+        Map<String, String> tags = new HashMap<String, String>();
+        tags.put("tag1Key", "tag1Value");
+        Map<String, Object> fields = new HashMap<String, Object>();
+        fields.put("field1Key", "field1Value");
+        InfluxDbPoint point1 = new InfluxDbPoint("aaa", tags, 456l, fields);
+        Set<InfluxDbPoint> set = new HashSet<InfluxDbPoint>();
+        set.add(point1);
+        InfluxDbWriteObject influxDbWriteObject = mock(InfluxDbWriteObject.class);
+        when(influxDbWriteObject.getPoints()).thenReturn(set);
+        when(influxDbWriteObject.getPrecision()).thenReturn(TimeUnit.MICROSECONDS);
+        InfluxDbWriteObjectSerializer influxDbWriteObjectSerializer = new InfluxDbWriteObjectSerializer("");
+        String lineString = influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject, "xxx");
+        assertThat(lineString).isEqualTo(
+                "xxx,tag1Key=tag1Value aaa.field1Key=\"field1Value\" 456000\n");
+        InfluxDbPoint point2 = new InfluxDbPoint("bbb", tags, 456l, fields);
+        set.add(point2);
+        lineString = influxDbWriteObjectSerializer.getGroupedLineProtocolString(influxDbWriteObject, "xxx");
+        assertThat(lineString).isEqualTo(
+                "xxx,tag1Key=tag1Value aaa.field1Key=\"field1Value\",bbb.field1Key=\"field1Value\" 456000\n");
+    }
+
+    @Test
     public void shouldOmitNaNsEtcWhenSerializingUsingLineProtocolForDouble() {
         Map<String, Object> fields = new LinkedHashMap<String, Object>();
         fields.put("field1Key", "field1Value");


### PR DESCRIPTION
This is an attempt to get a change done by our company finally merged into the latest. See https://github.com/iZettle/dropwizard-metrics-influxdb/pull/72 for details on what this pull request is based on.

Here is the description from the original PR:

> Our organization needs to group all the fields under one measurement and transmit them as one measurement. This alternate serialization can be had by instantiating GroupedInfluxDbHttpSender instead of InfluxDbHttpSender.

There was a comment made by @rickard-von-essen-iz on 10/17/2017 requesting that a detailed documentation. This PR adds that detailed documentation and also merged in master from the main branch to bring it up to version 1.3.0 (it was based off version 1.1.9).

Please review and let me know if this needs further details/further work.