### PR TITLE
Add measurement mapping for jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ defaultMeasurementMappings:
   resources: .*\.resources?.*
   event_handlers: .*Handler.*
   datasources: io\.dropwizard\.db\.ManagedPooledDataSource.*
+  jobs: .*\..*Job$
   clients: org\.apache\.http\.client\.HttpClient.*
   client_connections: org\.apache\.http\.conn\.HttpClientConnectionManager.*
   connections: org\.eclipse\.jetty\.server\.HttpConnectionFactory.*

--- a/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
+++ b/dropwizard-metrics-influxdb/src/main/java/com/izettle/metrics/dw/InfluxDbReporterFactory.java
@@ -120,6 +120,7 @@ import io.dropwizard.validation.ValidationMethod;
  *             dao = *\.(jdbi|dao)\..*<br>
  *             resources = *\.resources?\..*<br>
  *             datasources = io\.dropwizard\.db\.ManagedPooledDataSource.*<br>
+ *             jobs = .*\..*Job$<br>
  *             clients = org\.apache\.http\.client\.HttpClient.*<br>
  *             client_connections = org\.apache\.http\.conn\.HttpClientConnectionManager.*<br>
  *             connections = org\.eclipse\.jetty\.server\.HttpConnectionFactory.*<br>
@@ -205,6 +206,7 @@ public class InfluxDbReporterFactory extends BaseReporterFactory {
         .put("resources", ".*\\.resources?\\..*")
         .put("event_handlers", ".*\\.messaging\\..*")
         .put("datasources", "io\\.dropwizard\\.db\\.ManagedPooledDataSource.*")
+        .put("jobs", ".*\\..*Job$")
         .put("clients", "org\\.apache\\.http\\.client\\.HttpClient.*")
         .put("client_connections", "org\\.apache\\.http\\.conn\\.HttpClientConnectionManager.*")
         .put("connections", "org\\.eclipse\\.jetty\\.server\\.HttpConnectionFactory.*")


### PR DESCRIPTION
https://github.com/dropwizard-jobs/dropwizard-jobs has built-in metrics that
could be registered in DW either manually or by using `JobsBundle`.

This PR adds mappings on such metrics and put them into measurement `jobs`.

It requires the job class to have `Job` at the end of its class name.