### PR TITLE
Dependabot cleanup

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,3 +1,0 @@
-- match:
-    dependency_type: all
-    update_type: "semver:minor"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,21 +1,8 @@
 name: Auto approve
 
-on: pull_request_target
+on:
+  pull_request_target
 
 jobs:
   auto-approve:
-    name: Auto approve dependabot pull requests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: hmarr/auto-approve-action@v2
-        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
-        with:
-          github-token: "${{ secrets.BOT_GITHUB_TOKEN }}"
-  auto-merge:
-    name: Auto merge
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2
-        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
-        with:
-          github-token: "${{ secrets.BOT_GITHUB_TOKEN }}"
+    uses: iZettle/.github/.github/workflows/dependabot-approve-and-merge.yml@main


### PR DESCRIPTION
_Why?_ The main motivation is to ensure that this repo is continually up to date on the main branch. This ensures we are integrating dependency updates which include security patches as quickly as possible.

_How?_ This replaces some boilerplate Dependabot configuration with a [common Zettle approve and merge workflow](https://github.com/iZettle/.github/blob/main/.github/workflows/dependabot-approve-and-merge.yml)
