### PR TITLE
Dependabot: This public repo doesn't need private registry conf

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,8 @@
 ---
 version: 2
-registries:
-  artifactory-libs-release:
-    type: maven-repository
-    url: https://cizettle.jfrog.io/cizettle/libs-release
-    username: ${{ secrets.CIZETTLE_JFROG_IO_USER }}
-    password: ${{ secrets.CIZETTLE_JFROG_IO_PASSWORD }}
 updates:
 - package-ecosystem: "maven"
   open-pull-requests-limit: 20
-  registries:
-    - artifactory-libs-release
   directory: "/"
   schedule:
     interval: "weekly"


### PR DESCRIPTION
_Why?_ This repo produces public artifacts and shouldn't rely on private dependencies.
_Why?_ Hopefully gets dependabot to work again 
_Why?_ Hopefully closes #192 once dependabot kicks in